### PR TITLE
Fix/promote allow echo

### DIFF
--- a/.github/workflows/promote-post.yml
+++ b/.github/workflows/promote-post.yml
@@ -92,6 +92,6 @@ jobs:
 
             Post files to promote:
             ${{ steps.find.outputs.posts }}
-          claude_args: --allowedTools "Read,Bash(buffer-cli:*)"
+          claude_args: --allowedTools "Read,Bash(buffer-cli:*),Bash(echo:*)"
         env:
           BUFFER_AUTH_TOKEN: ${{ secrets.BUFFER_AUTH_TOKEN }}

--- a/.github/workflows/promote-post.yml
+++ b/.github/workflows/promote-post.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The dry-run showed 15 permission denials because Claude uses echo-pipe
patterns (echo -n "$text" | wc -c) to validate character limits before
posting. Adding Bash(echo:*) to the allowlist lets those checks pass
without opening broader shell access — the pattern cannot match curl,
git, rm, or any other command.