### PR TITLE
Refine code review workflows to use label-based triggering

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ jobs:
   claude-review:
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login == 'kakkoyun' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, labeled]
+    paths:
+      - 'content/posts/**'
+      - 'content/talks/**'
+      - 'content/notes/**'
 
 jobs:
   claude-review:
     if: >-
       github.event.pull_request.draft == false &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event.pull_request.user.login == 'kakkoyun' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/prose-review.yml
+++ b/.github/workflows/prose-review.yml
@@ -11,7 +11,7 @@ jobs:
   prose-review:
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.user.login == 'kakkoyun' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       (github.event.action != 'labeled' || github.event.label.name == 'prose-review')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/prose-review.yml
+++ b/.github/workflows/prose-review.yml
@@ -2,7 +2,7 @@ name: Prose Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, labeled]
     paths:
       - 'content/posts/**/*.md'
       - 'content/talks/**/*.md'
@@ -11,7 +11,8 @@ jobs:
   prose-review:
     if: >-
       github.event.pull_request.draft == false &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event.pull_request.user.login == 'kakkoyun' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'prose-review')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Updated the Claude Code Review and Prose Review GitHub Actions workflows to use label-based triggering instead of the `synchronize` event, allowing more granular control over when reviews are executed.

## Key Changes
- **Trigger events**: Replaced `synchronize` with `labeled` event type in both workflows
  - Claude Code Review: `[opened, synchronize, ready_for_review, reopened]` → `[opened, ready_for_review, reopened, labeled]`
  - Prose Review: `[opened, synchronize, ready_for_review, reopened]` → `[opened, ready_for_review, reopened, labeled]`

- **Conditional logic**: Added label-based filtering to prevent unnecessary workflow runs
  - Claude Code Review: Only runs on `labeled` events when the label is `claude-review`
  - Prose Review: Only runs on `labeled` events when the label is `prose-review`

- **Path filters**: Added explicit path filters to Claude Code Review workflow (was missing)
  - Targets: `content/posts/**`, `content/talks/**`, `content/notes/**`

## Implementation Details
The workflows now use a conditional expression that allows the `labeled` event to trigger only when the specific review label is applied:
```
(github.event.action != 'labeled' || github.event.label.name == '<review-label>')
```

This prevents the workflows from running on every label addition while still allowing manual triggering via specific labels, and maintains automatic triggering on `opened`, `ready_for_review`, and `reopened` events.

https://claude.ai/code/session_01NTDiGa8FiFzeXxoRKrzjPf