### PR TITLE
Skip Netlify preview builds when only non-content files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,32 @@ name: Build & Verify
 on:
   push:
     branches: [master]
+    paths:
+      - 'content/**'
+      - 'layouts/**'
+      - 'themes/**'
+      - 'static/**'
+      - 'assets/**'
+      - 'archetypes/**'
+      - 'config.yaml'
+      - '.hugo-version'
+      - 'scripts/verify-build.sh'
+      - '.lighthouserc.yml'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [master]
+    paths:
+      - 'content/**'
+      - 'layouts/**'
+      - 'themes/**'
+      - 'static/**'
+      - 'assets/**'
+      - 'archetypes/**'
+      - 'config.yaml'
+      - '.hugo-version'
+      - 'scripts/verify-build.sh'
+      - '.lighthouserc.yml'
+      - '.github/workflows/build.yml'
 
 jobs:
   build-verify:

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,12 +16,14 @@ HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+ignore = "bash scripts/netlify-ignore.sh"
 
 [context.deploy-preview.environment]
 HUGO_VERSION = "0.161.1"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+ignore = "bash scripts/netlify-ignore.sh"
 
 [context.branch-deploy.environment]
 HUGO_VERSION = "0.161.1"

--- a/scripts/netlify-ignore.sh
+++ b/scripts/netlify-ignore.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Netlify ignore command for non-production deploys.
+#
+# Wired into [context.deploy-preview] and [context.branch-deploy] in
+# netlify.toml. Skips the build (exit 0) when nothing under a path that
+# affects the rendered site has changed since the last deployed commit;
+# otherwise builds (exit non-zero).
+#
+# Netlify sets these in the build environment:
+#   CACHED_COMMIT_REF  SHA of the last successful deploy on this context
+#   COMMIT_REF         SHA being considered for deploy
+#   CONTEXT            deploy-preview | branch-deploy | production | ...
+
+set -uo pipefail
+
+# Anything outside this list (.github/, .claude/, scripts/, docs/,
+# Makefile, *.md at the repo root, .vale.ini, styles/, renovate.json,
+# tools/, .gitignore, .gitmodules, .lighthouserc.yml) does not change
+# what Hugo renders and does not need a preview.
+BUILD_PATHS=(
+  ".hugo-version"
+  "archetypes/"
+  "assets/"
+  "config.yaml"
+  "content/"
+  "layouts/"
+  "netlify.toml"
+  "static/"
+  "themes/"
+)
+
+# First deploy on this branch — nothing to diff against. Build.
+if [[ -z "${CACHED_COMMIT_REF:-}" ]]; then
+  echo "netlify-ignore: no cached commit, building."
+  exit 1
+fi
+
+# Manual redeploy of the same commit — nothing changed, by definition.
+if [[ "${CACHED_COMMIT_REF}" == "${COMMIT_REF:-}" ]]; then
+  echo "netlify-ignore: cached commit == current commit, skipping."
+  exit 0
+fi
+
+if git diff --quiet "${CACHED_COMMIT_REF}" "${COMMIT_REF}" -- "${BUILD_PATHS[@]}"; then
+  echo "netlify-ignore: no site-affecting paths changed since ${CACHED_COMMIT_REF}, skipping."
+  exit 0
+fi
+
+echo "netlify-ignore: site-affecting paths changed since ${CACHED_COMMIT_REF}, building."
+exit 1

--- a/scripts/netlify-ignore.sh
+++ b/scripts/netlify-ignore.sh
@@ -13,10 +13,12 @@
 
 set -uo pipefail
 
-# Anything outside this list (.github/, .claude/, scripts/, docs/,
-# Makefile, *.md at the repo root, .vale.ini, styles/, renovate.json,
-# tools/, .gitignore, .gitmodules, .lighthouserc.yml) does not change
-# what Hugo renders and does not need a preview.
+# Anything outside this list (.github/, .claude/, the rest of scripts/,
+# docs/, Makefile, *.md at the repo root, .vale.ini, styles/,
+# renovate.json, tools/, .gitignore, .gitmodules, .lighthouserc.yml)
+# does not change what Hugo renders and does not need a preview.
+# `scripts/netlify-ignore.sh` is itself included so a change to the
+# deploy gate triggers a verifying build.
 BUILD_PATHS=(
   ".hugo-version"
   "archetypes/"
@@ -25,6 +27,7 @@ BUILD_PATHS=(
   "content/"
   "layouts/"
   "netlify.toml"
+  "scripts/netlify-ignore.sh"
   "static/"
   "themes/"
 )
@@ -35,8 +38,15 @@ if [[ -z "${CACHED_COMMIT_REF:-}" ]]; then
   exit 1
 fi
 
+# Netlify always sets COMMIT_REF; guard explicitly so local runs or
+# unexpected env shape fall through to "build" instead of erroring on `set -u`.
+if [[ -z "${COMMIT_REF:-}" ]]; then
+  echo "netlify-ignore: COMMIT_REF not set, building."
+  exit 1
+fi
+
 # Manual redeploy of the same commit — nothing changed, by definition.
-if [[ "${CACHED_COMMIT_REF}" == "${COMMIT_REF:-}" ]]; then
+if [[ "${CACHED_COMMIT_REF}" == "${COMMIT_REF}" ]]; then
   echo "netlify-ignore: cached commit == current commit, skipping."
   exit 0
 fi


### PR DESCRIPTION
## Summary
Skip Netlify previews and the GitHub `Build & Verify` workflow on PRs that don't touch site-affecting files. Netlify's native `ignore` mechanism handles the preview side; `paths:` filters handle the GitHub Actions side.

## Key Changes
- **Added `scripts/netlify-ignore.sh`**: bash script wired into Netlify's `ignore` attribute that decides whether a preview should build:
  - Builds on the first deploy (no `$CACHED_COMMIT_REF` to diff against — safe default)
  - Builds when `$COMMIT_REF` is unset/empty (safe default for local runs)
  - Skips when redeploying the exact same commit
  - Compares `git diff $CACHED_COMMIT_REF $COMMIT_REF` against a curated `BUILD_PATHS` whitelist (content, layouts, themes, static, assets, archetypes, `config.yaml`, `.hugo-version`, `netlify.toml`, the ignore script itself) — skips when no whitelisted path changed
  - Exits 0 (skip) or non-zero (build); Netlify treats non-zero as "build"

- **Updated `netlify.toml`**: wired the ignore script into `[context.deploy-preview]` and `[context.branch-deploy]`. Production is intentionally not gated — master merges always deploy.

- **Updated `.github/workflows/build.yml`**: added `paths:` filters on both `push` and `pull_request` so the Hugo build + Lighthouse jobs only run when something they actually consume changes (`content/`, `layouts/`, `themes/`, `static/`, `assets/`, `archetypes/`, `config.yaml`, `.hugo-version`, `scripts/verify-build.sh`, `.lighthouserc.yml`, the workflow file).

## Why not gate at CI level only
Netlify watches the repo webhook directly; GitHub Actions can't cleanly tell it "don't build this PR" without disabling Netlify's native PR-preview integration. The `ignore` command is Netlify's contract for this exact decision, so it lives there. `build.yml` is gated separately in its own CI.

https://claude.ai/code/session_01N2VNvfPFHmiuEgyYY3TXA1