### PR TITLE
ci(links): add --root-dir to links-new-content so --scheme can apply

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -113,6 +113,12 @@ jobs:
           #   are skipped entirely — links-internal already validates them
           #   against the built site, and root-relative links to assets added
           #   in this same PR do not yet exist on the live site.
+          # --root-dir: lychee needs a root dir to parse root-relative URLs
+          #   like /talks/foo into file:// URLs before any filter applies.
+          #   Without it, parsing fails with a hard error and --scheme never
+          #   gets a chance to skip them. The path is only used for URL
+          #   construction; the resulting file:// URLs are then filtered out
+          #   by --scheme http/https.
           args: >-
             --verbose
             --no-progress
@@ -124,6 +130,7 @@ jobs:
             --accept '200..=299,403,429'
             --scheme http
             --scheme https
+            --root-dir "${{ github.workspace }}"
             --exclude 'linkedin.com'
             --exclude 'twitter.com'
             --exclude 'x.com'


### PR DESCRIPTION
## Summary

Reported failure on an open PR adding `from-talk-to-docs-the-zen-of-prometheus.md`:

```
[ERROR] Error building URL for "/talks/the-zen-of-prometheus/"
        | Cannot convert path to a URI: To resolve root-relative
        | links in local files, provide a root dir
```

`links-new-content` set `--scheme http --scheme https` intending to skip root-relative URLs like `/talks/foo`. But lychee's `--scheme` filter only applies **after** URLs are parsed — and root-relative paths fail to parse without `--root-dir`, raising a hard error before the filter gets a chance to skip them.

Adding `--root-dir "${{ github.workspace }}"` lets lychee build `file://` URLs for those paths. The `--scheme http/https` filter then excludes the `file://` URLs, which was the original intent.

## Test plan

- [x] `actionlint .github/workflows/links.yml` clean
- [x] Reproduced bug locally against `content/posts/fosdem-2026.md` (has 7 root-relative `/talks/*` and `/uploads/*` links): 11 hard parse errors without `--root-dir`
- [x] Verified fix: with `--root-dir "$PWD"`, all 7 root-relative URLs are excluded by scheme filter (`👻 7 Excluded`), 0 parse errors
- [ ] CI green on this PR
- [ ] Re-running the originally-failing PR's CI succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_015gScdrvM4UYqNjyMgCNsPZ)_