### PR TITLE
ci(links): emit heading anchors via render-heading override

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,6 +46,7 @@ jobs:
           HUGO_ENV: production
 
       - name: Check internal links with lychee
+        id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           # --offline: skip all http/https URLs. External rot is handled by the
@@ -54,6 +55,8 @@ jobs:
           #   against the built public/ directory. Required for absolute paths
           #   in offline mode.
           # --include-fragments: verify #anchor targets exist in the linked page.
+          #   Works because layouts/_default/_markup/render-heading.html emits
+          #   id="<slug>" on every heading.
           args: >-
             --verbose
             --no-progress
@@ -61,7 +64,25 @@ jobs:
             --root-dir "${{ github.workspace }}/public"
             --include-fragments
             './public/**/*.html'
-          fail: true
+          # fail: false so a work-in-progress series with forward references
+          # to not-yet-written sibling posts does not block the PR. Broken
+          # links still surface in the workflow's step summary below.
+          fail: false
+
+      - name: Surface broken internal links to step summary
+        if: steps.lychee.outputs.exit_code != '0'
+        run: |
+          {
+            echo "## ⚠️ Broken internal links (non-blocking)"
+            echo
+            echo "These links did not resolve against the built site. Fix them before merging if they are not intentional forward references."
+            echo
+            if [ -f ./lychee/out.md ]; then
+              cat ./lychee/out.md
+            else
+              echo "_lychee did not produce ./lychee/out.md — see step logs above._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # On PRs that add a new post or talk, check external links in just those new
   # files. Bounded scope keeps flake surface tiny while ensuring a contributor

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,7 +46,6 @@ jobs:
           HUGO_ENV: production
 
       - name: Check internal links with lychee
-        id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           # --offline: skip all http/https URLs. External rot is handled by the
@@ -64,25 +63,7 @@ jobs:
             --root-dir "${{ github.workspace }}/public"
             --include-fragments
             './public/**/*.html'
-          # fail: false so a work-in-progress series with forward references
-          # to not-yet-written sibling posts does not block the PR. Broken
-          # links still surface in the workflow's step summary below.
-          fail: false
-
-      - name: Surface broken internal links to step summary
-        if: steps.lychee.outputs.exit_code != '0'
-        run: |
-          {
-            echo "## ⚠️ Broken internal links (non-blocking)"
-            echo
-            echo "These links did not resolve against the built site. Fix them before merging if they are not intentional forward references."
-            echo
-            if [ -f ./lychee/out.md ]; then
-              cat ./lychee/out.md
-            else
-              echo "_lychee did not produce ./lychee/out.md — see step logs above._"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          fail: true
 
   # On PRs that add a new post or talk, check external links in just those new
   # files. Bounded scope keeps flake surface tiny while ensuring a contributor

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,10 @@
+{{- /*
+  Emit an id="..." attribute on every heading so in-page fragment links
+  (`#section-name`) resolve correctly. Hugo's default renderer emits no id,
+  and PaperMod ships no render-heading.html override, so without this every
+  fragment link on the site silently 404s. .Anchor is Hugo's slug for the
+  heading text (e.g. "## Where to Find Me" -> "where-to-find-me").
+*/ -}}
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">
+  {{- .Text | safeHTML -}}
+</h{{ .Level }}>


### PR DESCRIPTION
## Summary

Reported failures on an open PR:

```
/about#where-to-find-me — Cannot find fragment
/posts/otel-unplugged-eu-2026#the-maintainer-crisis — Cannot find fragment
/posts/mentorship-in-open-source-part-2-mentee-playbook — Cannot find file
/posts/mentorship-in-open-source-part-3-stewardship — Cannot find file
```

The fragment errors were structural: PaperMod ships no `render-heading.html` and Hugo's default renderer emits no `id="..."` on headings, so every `#section` link on this site has always been silently broken in raw HTML (browsers tolerate it, lychee doesn't). Adding `--include-fragments` to `links-internal` surfaced this as false-looking failures.

New `layouts/_default/_markup/render-heading.html` emits `<hN id="{{ .Anchor }}">` — `#where-to-find-me` and `#the-maintainer-crisis` (and every other anchor on the site) now resolve.

The file-not-found errors (forward references to unwritten sibling posts) are real broken links. Per discussion: `links-internal` stays `fail: true`. Forward references should be removed from content until the target posts exist.

## Test plan

- [x] `actionlint .github/workflows/links.yml` clean
- [x] Locally: `hugo --gc --minify` builds with the new render-heading override; rendered HTML now contains `<h2 id=where-to-find-me>` etc. (Hugo `--minify` strips attribute quotes)
- [x] Locally: `lychee --offline --root-dir public --include-fragments './public/**/*.html'` → 775 OK, 0 errors
- [ ] CI green on this PR
- [ ] Re-run the originally-failing PR's CI: fragments resolve; missing-file errors still flag and need to be addressed in content