### PR TITLE
ci: enable track_progress and disable inline-comment classifier on Claude reviewers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,5 +35,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          track_progress: true
+          classify_inline_comments: false
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/prose-review.yml
+++ b/.github/workflows/prose-review.yml
@@ -33,6 +33,8 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          track_progress: true
+          classify_inline_comments: false
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary

Follow-up to #156. PR #133 confirmed that both reviewers were still silent after the label-only refactor — running 2–4 minutes, exiting `success`, posting zero reviews/comments/threads.

Reading `anthropics/claude-code-action` docs surfaced two relevant defaults:

- **`track_progress: false`** — no progress comment, so a no-op run is invisible from outside the action log.
- **`classify_inline_comments: true`** — inline comments are buffered and routed through a Haiku classifier; anything not explicitly marked `confirmed: true` gets dropped as a "test/probe". This silently filters out review comments the plugin generates.

This PR sets both:

```yaml
track_progress: true
classify_inline_comments: false
```

on both `claude-code-review.yml` and `prose-review.yml`.

## Diagnostics this gives us

| Observed after this PR | Means |
|---|---|
| Progress comment + review appears | Fixed. |
| Progress comment, no review | Plugin ran, decided nothing to flag (or the prose prompt isn't producing findings). Iterate on the prompt. |
| No progress comment at all | Issue is auth, billing, or action wiring — not the classifier. |

## Test plan

- [ ] Open / re-open a content PR and apply `claude-review`; confirm a progress comment appears within ~30s of the workflow starting.
- [ ] Same PR, apply `prose-review`; confirm a progress comment from the prose run too.
- [ ] If a review surfaces, spot-check that inline comments are posted as-is (no Haiku classifier dropping them).
- [ ] Confirm `actionlint` still passes.

Refs #156, #133.

https://claude.ai/code/session_01PaqBiFqoSfq3jH1LDUB7Te

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaqBiFqoSfq3jH1LDUB7Te)_