### PR TITLE
fix(newsletter): correct Hakanai subscribe endpoint + add JS handler

### DIFF
--- a/assets/css/extended/newsletter.css
+++ b/assets/css/extended/newsletter.css
@@ -154,6 +154,20 @@
   color: var(--secondary);
 }
 
+.newsletter-form__success {
+  margin: 0.75rem 0 0;
+  max-width: 24rem;
+  padding: 0.45rem 0;
+  font-size: 0.95rem;
+  color: var(--content);
+}
+
+.newsletter-form__error {
+  margin: 0.45rem 0 0;
+  font-size: 0.85em;
+  color: var(--secondary);
+}
+
 @media (max-width: 480px) {
   .newsletter-form {
     max-width: 100%;

--- a/assets/css/extended/newsletter.css
+++ b/assets/css/extended/newsletter.css
@@ -154,18 +154,63 @@
   color: var(--secondary);
 }
 
+/* Success + error feedback rendered after a fetch() round-trip. Both
+   carry an emoji prefix (CSS pseudo-element) so the meaning reads
+   even when colour-blindness or terminal renderings flatten the
+   hue. Theme-aware via :root[data-theme="dark"] overrides; the
+   light-theme values are the defaults.
+*/
 .newsletter-form__success {
   margin: 0.75rem 0 0;
   max-width: 24rem;
-  padding: 0.45rem 0;
+  padding: 0.5rem 0.7rem;
   font-size: 0.95rem;
-  color: var(--content);
+  font-weight: 500;
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.10);
+  border-left: 3px solid #16a34a;
+  border-radius: 4px;
+  outline: none;
+}
+
+.newsletter-form__success::before {
+  content: "✓ ";
+  font-weight: 700;
+  margin-right: 0.15rem;
 }
 
 .newsletter-form__error {
-  margin: 0.45rem 0 0;
-  font-size: 0.85em;
-  color: var(--secondary);
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.9em;
+  font-weight: 500;
+  color: #b91c1c;
+  background: rgba(220, 38, 38, 0.10);
+  border-left: 3px solid #dc2626;
+  border-radius: 4px;
+}
+
+.newsletter-form__error::before {
+  content: "⚠ ";
+  font-weight: 700;
+  margin-right: 0.15rem;
+}
+
+.newsletter-form__error a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+:root[data-theme="dark"] .newsletter-form__success {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.18);
+  border-color: #22c55e;
+}
+
+:root[data-theme="dark"] .newsletter-form__error {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.18);
+  border-color: #ef4444;
 }
 
 @media (max-width: 480px) {

--- a/layouts/partials/newsletter-form.html
+++ b/layouts/partials/newsletter-form.html
@@ -5,19 +5,25 @@
 
     - With campaignId  --> a real <form> that submits to
       {hakanaiHost}/api/campaign/{campaignId}/subscribe?email=...
-      Hakanai's API reads "email" from the URL query (verified by
-      probing the live endpoint; their SPA's own client builds the
-      same URL pattern). A small inline JS handler intercepts the
-      submit and calls the API via fetch(), then swaps the form for
-      a thank-you message. Without JS the form still submits (GET to
-      the same URL), the API still subscribes the user, but the user
-      sees raw JSON --- acceptable graceful degradation.
+      This URL pattern is what the campaign's Forms tab in the
+      Hakanai dashboard shows verbatim. A successful subscribe
+      returns HTTP 200 with the campaign metadata as JSON
+      ({"name":"...","url":"..."}) --- that response IS the success
+      signal; Hakanai sends the double-opt-in email asynchronously.
 
-      The earlier action URL --- /campaign/{id}/subscribe without
-      /api/ --- was Hakanai's SPA page, not a server route. POSTs to
-      it hang indefinitely because no handler exists for that verb.
-      See debug/hakanai-subscribe-test (now deleted) for the probes
-      that uncovered this.
+      A small inline JS handler intercepts the submit, calls the API
+      via fetch(), and swaps the form for a thank-you message with
+      role=status + aria-live=polite + focus shift so screen readers
+      pick it up. Errors get role=alert + aria-live=assertive.
+      Without JS, the form submits via GET to the same URL --- the
+      API still subscribes the user, but they end up on Hakanai's
+      JSON response page; acceptable degradation.
+
+      The docs example at hakanai.io/docs/broadcast/forms uses
+      "https://hakanai.io/api/subscribe/your-campaign-id" as a
+      *placeholder*, not a literal URL --- the per-campaign Forms
+      tab is what gives you the real action URL, which lives on
+      broadcast.hakanai.io.
 
     - Without campaignId --> a "coming soon" placeholder linking to email,
       used on publication landing pages whose per-publication campaign
@@ -39,6 +45,7 @@
 {{- $publication := .publication | default "" -}}
 {{- $campaignId := .campaignId | default "" -}}
 {{- $name := .name | default "" -}}
+{{- $contactEmail := site.Params.author.email -}}
 
 {{- /* Resolve from publication slug when one was passed in */ -}}
 {{- with $publication -}}
@@ -60,7 +67,7 @@
 {{- $inputId := printf "newsletter-email-%s" (or $publication "main") -}}
 
 {{- if $campaignId -}}
-<form class="newsletter-form" action="{{ $host }}/api/campaign/{{ $campaignId }}/subscribe" method="get" data-publication="{{ $publication }}">
+<form class="newsletter-form" action="{{ $host }}/api/campaign/{{ $campaignId }}/subscribe" method="get" data-publication="{{ $publication }}" data-contact-email="{{ $contactEmail }}">
   <div class="newsletter-form__row">
     <input
       id="{{ $inputId }}"
@@ -94,22 +101,37 @@
         if (button) { button.disabled = true; button.textContent = "Subscribing…"; }
         var existingError = form.querySelector(".newsletter-form__error");
         if (existingError) existingError.remove();
-        fetch(url, { method: "POST", headers: { Accept: "application/json" } })
+        fetch(url, { method: "GET", headers: { Accept: "application/json" } })
           .then(function (response) {
             if (!response.ok) throw new Error("HTTP " + response.status);
             var thanks = document.createElement("p");
             thanks.className = "newsletter-form__success";
+            thanks.setAttribute("role", "status");
+            thanks.setAttribute("aria-live", "polite");
+            thanks.setAttribute("tabindex", "-1");
             thanks.textContent = "Thanks! Check your inbox for a confirmation email.";
             form.replaceWith(thanks);
+            try { thanks.focus(); } catch (e) {}
           })
           .catch(function () {
             if (button) {
               button.disabled = false;
               button.textContent = originalLabel || "Subscribe";
             }
+            var contactEmail = form.dataset.contactEmail || "";
             var err = document.createElement("p");
             err.className = "newsletter-form__error";
-            err.textContent = "Subscription failed. Please try again, or email kakkoyun@gmail.com.";
+            err.setAttribute("role", "alert");
+            err.setAttribute("aria-live", "assertive");
+            err.textContent = "Subscription failed. Please try again";
+            if (contactEmail) {
+              err.appendChild(document.createTextNode(", or email "));
+              var link = document.createElement("a");
+              link.href = "mailto:" + contactEmail;
+              link.textContent = contactEmail;
+              err.appendChild(link);
+            }
+            err.appendChild(document.createTextNode("."));
             form.appendChild(err);
           });
       });
@@ -121,7 +143,7 @@
 <aside class="newsletter-form newsletter-form--placeholder" data-publication="{{ $publication }}" aria-label="Subscription form placeholder">
   <strong>Subscribe to {{ $name }}</strong>
   <p>Email subscription is coming soon. For now, email
-    <a href="mailto:{{ site.Params.author.email }}?subject=Newsletter">{{ site.Params.author.email }}</a>
+    <a href="mailto:{{ $contactEmail }}?subject=Newsletter">{{ $contactEmail }}</a>
     with the subject &ldquo;Newsletter&rdquo; and I&rsquo;ll add you.</p>
 </aside>
 {{- end -}}

--- a/layouts/partials/newsletter-form.html
+++ b/layouts/partials/newsletter-form.html
@@ -3,9 +3,21 @@
 
   Renders one of two states based on whether a campaignId is resolvable:
 
-    - With campaignId  --> a real <form> that POSTs to
-      {hakanaiHost}/campaign/{campaignId}/subscribe (the user-facing
-      form URL; Hakanai handles the redirect/confirmation page).
+    - With campaignId  --> a real <form> that submits to
+      {hakanaiHost}/api/campaign/{campaignId}/subscribe?email=...
+      Hakanai's API reads "email" from the URL query (verified by
+      probing the live endpoint; their SPA's own client builds the
+      same URL pattern). A small inline JS handler intercepts the
+      submit and calls the API via fetch(), then swaps the form for
+      a thank-you message. Without JS the form still submits (GET to
+      the same URL), the API still subscribes the user, but the user
+      sees raw JSON --- acceptable graceful degradation.
+
+      The earlier action URL --- /campaign/{id}/subscribe without
+      /api/ --- was Hakanai's SPA page, not a server route. POSTs to
+      it hang indefinitely because no handler exists for that verb.
+      See debug/hakanai-subscribe-test (now deleted) for the probes
+      that uncovered this.
 
     - Without campaignId --> a "coming soon" placeholder linking to email,
       used on publication landing pages whose per-publication campaign
@@ -48,7 +60,7 @@
 {{- $inputId := printf "newsletter-email-%s" (or $publication "main") -}}
 
 {{- if $campaignId -}}
-<form class="newsletter-form" action="{{ $host }}/campaign/{{ $campaignId }}/subscribe" method="post" data-publication="{{ $publication }}">
+<form class="newsletter-form" action="{{ $host }}/api/campaign/{{ $campaignId }}/subscribe" method="get" data-publication="{{ $publication }}">
   <div class="newsletter-form__row">
     <input
       id="{{ $inputId }}"
@@ -64,6 +76,47 @@
   </div>
   <p class="newsletter-form__note">No spam. Unsubscribe anytime.</p>
 </form>
+<script>
+(function () {
+  var forms = document.querySelectorAll("form.newsletter-form");
+  for (var i = 0; i < forms.length; i++) {
+    (function (form) {
+      if (form.dataset.bound) return;
+      form.dataset.bound = "1";
+      form.addEventListener("submit", function (event) {
+        event.preventDefault();
+        var emailInput = form.querySelector("input[type=email]");
+        var email = emailInput && emailInput.value;
+        if (!email) return;
+        var url = form.getAttribute("action") + "?email=" + encodeURIComponent(email);
+        var button = form.querySelector("button[type=submit]");
+        var originalLabel = button ? button.textContent : "";
+        if (button) { button.disabled = true; button.textContent = "Subscribing…"; }
+        var existingError = form.querySelector(".newsletter-form__error");
+        if (existingError) existingError.remove();
+        fetch(url, { method: "POST", headers: { Accept: "application/json" } })
+          .then(function (response) {
+            if (!response.ok) throw new Error("HTTP " + response.status);
+            var thanks = document.createElement("p");
+            thanks.className = "newsletter-form__success";
+            thanks.textContent = "Thanks! Check your inbox for a confirmation email.";
+            form.replaceWith(thanks);
+          })
+          .catch(function () {
+            if (button) {
+              button.disabled = false;
+              button.textContent = originalLabel || "Subscribe";
+            }
+            var err = document.createElement("p");
+            err.className = "newsletter-form__error";
+            err.textContent = "Subscription failed. Please try again, or email kakkoyun@gmail.com.";
+            form.appendChild(err);
+          });
+      });
+    })(forms[i]);
+  }
+})();
+</script>
 {{- else -}}
 <aside class="newsletter-form newsletter-form--placeholder" data-publication="{{ $publication }}" aria-label="Subscription form placeholder">
   <strong>Subscribe to {{ $name }}</strong>


### PR DESCRIPTION
## TL;DR

The homepage subscribe form on `kakkoyun.me` is currently a no-op — submitting hangs forever (the symptom you saw on mobile). Root cause + fix found by probing the live endpoint from a GitHub Actions runner (#165).

## What was wrong

The form pointed at:

```
POST https://broadcast.hakanai.io/campaign/{id}/subscribe
Content-Type: application/x-www-form-urlencoded
Body: email=…
```

But that URL is Hakanai's **Nuxt SPA page**, not a server endpoint. Probes against the live host:

| Probe | Result |
| --- | --- |
| `POST /campaign/{id}/subscribe` (form-encoded) | **Timeout after 30s, 0 bytes** (no POST handler) |
| `POST /campaign/{id}/subscribe` (multipart) | Same timeout |
| `GET /campaign/{id}/subscribe` | 200 — but the response HTML has zero `<form>` elements; the page is client-side rendered |
| `POST /api/campaign/{id}/subscribe` (JSON body) | 500 — `Required parameter "email" was null or undefined when calling subscribe()` |
| `POST /api/campaign/{id}/subscribe?email=…` | **200 OK** → `{"name":"Not so Random Association","url":"https://kakkoyun.me"}` ✅ |
| `GET /api/campaign/{id}/subscribe?email=…`  | **200 OK** → same response ✅ |

The Nuxt bundle on the SPA page even embeds the literal URL `/api/campaign/{id}/subscribe?email=undefined` — the API reads `email` from the **query string**, not the body.

## What this PR changes

`layouts/partials/newsletter-form.html`:

- Action URL gets the `/api/` prefix:
  `https://broadcast.hakanai.io/api/campaign/{id}/subscribe`
- `method="post"` → `method="get"` so no-JS submission still subscribes the user (they see raw JSON in their browser but the request succeeds).
- ~30 lines of inline vanilla JS that intercepts the submit, calls fetch with `?email=…`, and on 200 swaps the form for a `<p class="newsletter-form__success">Thanks! Check your inbox…</p>`. On error it re-enables the button and shows an inline error message. Idempotent via `data-bound`.

`assets/css/extended/newsletter.css`:
- Theme-aware `.newsletter-form__success` and `.newsletter-form__error` styles.

## Verified

- Probed the live endpoint with `kakkoyun@gmail.com` — 200 OK, returned campaign metadata. Hakanai sends the double-opt-in confirmation email immediately. **Your inbox should show one already.**
- Local build: `make verify` passes; rendered homepage carries the new action URL + the inline JS.

## Cleanup follow-up

Once this merges, I'll close PR #166 + delete the `debug/hakanai-subscribe-test` branch + close #165. The debug workflow only ran on that branch, so it's a no-op on master.

Refs: #165

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfnYuF96c8gyJ1puMAgPc2)_