### PR TITLE
ci: extract prose-review procedure into a /prose-review slash command

### DIFF
--- a/.claude/commands/prose-review.md
+++ b/.claude/commands/prose-review.md
@@ -1,0 +1,41 @@
+---
+description: Prose-focused review of a pull request. Wraps the upstream code-review plugin with prose-specific priorities (banned vocab, formulaic openers, em-dash density) for blog post PRs under content/posts/ or content/talks/. Argument is a PR reference like owner/repo/pull/N.
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh search:*), Bash(gh issue list:*), Read
+---
+
+# Prose review
+
+/code-review:code-review $ARGUMENTS --comment
+
+Apply the review above as a PROSE-ONLY review of a blog post under `content/posts/` or `content/talks/`.
+
+Before commenting, read:
+
+1. [REVIEW.md](../../REVIEW.md) — target tone, banned vocab, patterns to scrutinise.
+2. [.claude/skills/kemal-voice/SKILL.md](../skills/kemal-voice/SKILL.md) — replacements for banned vocab, formulaic openers, editing checklist, tone-by-category notes.
+
+Review only the prose changes on the PR diff. Skip code blocks, frontmatter, shortcode arguments, and link targets.
+
+Target tone for the blog: clear, explanatory, fun, whimsical, honest, open. The author takes the technical material seriously but does not take themselves seriously. Use this as your calibration when judging "does this sound right".
+
+## Findings to flag, in priority order
+
+1. **Banned vocabulary** from the Vocabulary list (delve, tapestry, leverage, utilize, seamless, paradigm, ecosystem, etc.). High priority.
+2. **Formulaic AI openers** (paragraph starts with "In this post, we'll", "Let's dive into", "It's worth noting that", "At its core", "In conclusion", etc.). High priority.
+3. **Em-dash density**: 3+ em-dashes packed into one paragraph reads as AI-flavored. A single em-dash is fine.
+4. **"It's not X, it's Y" negative parallelism**: classic AI rhetorical pattern. Flag if the contrast is not load-bearing. A genuine contrast is fine.
+5. **Triadic rhythm** used more than once in a post. A single triad is fine; recurring triads feel like a tic.
+6. **Marketing or self-important tone**. Anything that sounds like a press release.
+
+## Do not flag
+
+- First person, contractions, or casual phrasing — those are on-tone.
+- Humor, asides, self-deprecation, or whimsy — those are on-tone.
+- Passive voice in technical contexts where the actor is irrelevant.
+- Honest hedging like "I'm not sure" or "this is a proof of concept" — those are on-tone.
+
+## Output
+
+- Up to 5 inline comments, one sentence each, prose-only.
+- One summary comment with category-fit assessment, any unflagged patterns worth a second look, and a verdict (`ship` / `minor edits` / `revise`).
+- Advisory only. Never request changes. Never block merge.

--- a/.github/workflows/prose-review.yml
+++ b/.github/workflows/prose-review.yml
@@ -36,31 +36,4 @@ jobs:
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
 
-            Apply the review above as a PROSE-ONLY review of a blog post under content/posts/ or content/talks/.
-
-            Before commenting, read:
-            1. REVIEW.md at the repo root, which sets the target tone and the patterns to scrutinize.
-            2. .claude/skills/kemal-voice/SKILL.md, which has banned vocabulary, formulaic openers, the editing checklist, and tone-by-category notes.
-
-            Then review only the prose changes on the PR diff. Skip code blocks, frontmatter, shortcode arguments, and link targets.
-
-            Target tone for the blog: clear, explanatory, fun, whimsical, honest, open. The author takes the technical material seriously but does not take themselves seriously. Use this as your calibration when judging "does this sound right".
-
-            Findings to flag, in priority order:
-            1. Banned vocabulary from the Vocabulary list (delve, tapestry, leverage, utilize, seamless, paradigm, ecosystem, etc.). High priority.
-            2. Formulaic AI openers (paragraph starts with "In this post, we'll", "Let's dive into", "It's worth noting that", "At its core", "In conclusion", etc.). High priority.
-            3. Em-dash density: 3+ em-dashes packed into one paragraph reads as AI-flavored. A single em-dash is fine.
-            4. "It's not X, it's Y" negative parallelism: classic AI rhetorical pattern. Flag if the contrast is not load-bearing. A genuine contrast is fine.
-            5. Triadic rhythm used more than once in a post. A single triad is fine; recurring triads feel like a tic.
-            6. Marketing or self-important tone. Anything that sounds like a press release.
-
-            Do not flag:
-            - First person, contractions, or casual phrasing — those are on-tone.
-            - Humor, asides, self-deprecation, or whimsy — those are on-tone.
-            - Passive voice in technical contexts where the actor is irrelevant.
-            - Honest hedging like "I'm not sure" or "this is a proof of concept" — those are on-tone.
-
-            Output:
-            - Up to 5 inline comments, one sentence each, prose-only.
-            - One summary comment with category-fit assessment, any unflagged patterns worth a second look, and a verdict (`ship` / `minor edits` / `revise`).
-            - Advisory only. Never request changes. Never block merge.
+            Apply this as a PROSE-ONLY review of a blog post under content/posts/ or content/talks/. Follow the procedure in `.claude/commands/prose-review.md`: read that file for the priority list, do-not-flag list, and output format, then apply those alongside the plugin's posting flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,8 @@ Three layered defenses against AI-slop prose. All advisory; none block merges.
 - **[REVIEW.md](REVIEW.md)** -- voice and prose-quality criteria. Companion to the Vale rules and the `prose-review.yml` workflow.
 - **[.claude/skills/kemal-voice/SKILL.md](.claude/skills/kemal-voice/SKILL.md)** -- Anthropic-format skill. Auto-loads when editing files under `content/posts/`, `content/talks/`, `content/notes/`. Encodes tone, banned vocabulary, formulaic openers, patterns to scrutinize, and tone-by-category notes.
 - **Vale** (`.vale.ini` + `styles/Slop/`) -- runs automatically on every content PR via `prose.yml` (reviewdog inline annotations). Run locally with `make vale`.
-- **`prose-review.yml`** -- Claude prose reviewer. Triggered on demand by applying the `prose-review` label to a PR. Reads `REVIEW.md` and the `kemal-voice` skill.
+- **[.claude/commands/prose-review.md](.claude/commands/prose-review.md)** -- `/prose-review` slash command. Wraps the upstream `code-review` plugin with prose-specific priorities (banned vocab, formulaic openers, em-dash density, do-not-flag list, output format). Single source of truth for the procedure; `prose-review.yml` references it. Invoke locally as `/prose-review owner/repo/pull/N` to review a PR before merging.
+- **`prose-review.yml`** -- Claude prose reviewer. Triggered on demand by applying the `prose-review` label to a PR. Follows the procedure in `.claude/commands/prose-review.md` and pulls voice rules from `REVIEW.md` and the `kemal-voice` skill.
 - **`claude-code-review.yml`** -- generic code reviewer. Triggered on demand by applying the `claude-review` label.
 
 **Target tone:** clear, explanatory, fun, whimsical, honest, open. Take the technical material seriously; do not take yourself seriously. See `REVIEW.md` for the full description.


### PR DESCRIPTION
## Summary

Extract the prose-review procedure (priority list, do-not-flag list, output format) out of `prose-review.yml`'s inline prompt and into `.claude/commands/prose-review.md` as a local `/prose-review` slash command. The workflow now references the file instead of duplicating its rules.

Single source of truth for the procedure. Same rules power both CI and local sessions.

## Files

- **`.claude/commands/prose-review.md`** (new) — `/prose-review owner/repo/pull/N` slash command. Body starts with `/code-review:code-review $ARGUMENTS --comment` so local invocation triggers the same upstream plugin posting flow the workflow uses. Followed by the priority list, do-not-flag list, and output format.
- **`.github/workflows/prose-review.yml`** — prompt collapses from ~30 lines of inline procedure to a 3-line wrapper that references `.claude/commands/prose-review.md` for the rules. Plugin invocation (`/code-review:code-review <pr> --comment`) on line 1 unchanged.
- **`CLAUDE.md`** — Prose Quality section updated to mention the new slash command.

## What's unchanged

- `kemal-voice` skill — still the voice/vocabulary source.
- `REVIEW.md` — still the editorial criteria source.
- `claude-code-review.yml` — generic code-review workflow, no prose-specific content to extract.
- Trigger model (label-gated multi-event) and permissions on both reviewers.

## Test plan

- [ ] Re-trigger prose-review on a content PR (apply/re-apply `prose-review` label). Confirm:
  - [ ] Reviewer fires and posts comments (same as PR #133 just did with the inline prompt).
  - [ ] Action log shows the slash command file being read.
- [ ] In a local Claude Code session, invoke `/prose-review kakkoyun/me/pull/<N>` on an open content PR and confirm it produces the same review output as CI.

https://claude.ai/code/session_01PaqBiFqoSfq3jH1LDUB7Te

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaqBiFqoSfq3jH1LDUB7Te)_