### PR TITLE
ci: tighten Lighthouse floors + per-audit assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ demo/
 # Hugo
 .hugo_build.lock
 
+# Lighthouse CI local run output
+.lighthouseci/
+
 # Node
 node_modules/
 

--- a/.lighthouserc.yml
+++ b/.lighthouserc.yml
@@ -9,17 +9,54 @@ ci:
 
   assert:
     assertions:
-      # Current scores: Performance 98, Accessibility 100, Best Practices 100, SEO 100
-      # Thresholds set ~10-15 points below current to catch significant regressions
+      # Category floors. Set ~3 points below the post-fix scores so any
+      # meaningful drop trips CI without being so tight that a single
+      # noisy audit blocks unrelated PRs.
       "categories:performance":
         - error
-        - minScore: 0.85
+        - minScore: 0.95
       "categories:accessibility":
         - error
-        - minScore: 0.90
+        - minScore: 0.97
       "categories:best-practices":
         - error
-        - minScore: 0.90
+        - minScore: 0.95
       "categories:seo":
         - error
-        - minScore: 0.90
+        - minScore: 0.97
+
+      # Per-audit assertions for regressions the category floors won't
+      # catch on their own. Each one corresponds to an issue we hit (and
+      # fixed) in #171; keep them as hard errors so re-introducing them
+      # blocks merges.
+
+      # CLS: Lighthouse's "good" boundary is 0.1. The home page banner
+      # was at 0.117 before the fix; lock it under that bar.
+      "cumulative-layout-shift":
+        - error
+        - maxNumericValue: 0.1
+
+      # Robots.txt validity. Lost SEO points the last time a non-standard
+      # directive crept in.
+      "robots-txt": error
+
+      # Accessibility audit that previously failed on the home page.
+      # (presentation-role-conflict was the other one — it lives in
+      # Lighthouse 13+ and isn't bundled with @lhci/cli yet, so the
+      # tightened accessibility floor above is what catches it.)
+      "link-in-text-block": error
+
+      # Image attributes — the banner regressed both of these when first
+      # given explicit width/height without `height: auto` CSS.
+      "image-aspect-ratio": error
+      "image-size-responsive": error
+
+      # Cover thumbnails in static/uploads/ legitimately can't be sized
+      # without moving them into assets/, so keep this informational
+      # rather than blocking. Surfacing it as a warning means it shows
+      # up in the report without failing CI.
+      "unsized-images": warn
+
+      # Console errors — sandbox MITM-style failures aren't real, so we
+      # stay informational rather than blocking on this in CI.
+      "errors-in-console": warn


### PR DESCRIPTION
## Summary

Follow-up to #171. The Lighthouse CI floors were set 6–13 points below the actual scores, so the regressions fixed in that PR all slid past unnoticed. The SEO drop from the bare URL in `robots.txt` cleared the existing `0.90` floor by just 2 points.

This tightens the bar in two complementary ways:

**1. Raise category floors to ~3 points below current.**

| Category | Old floor | New floor | Margin from "good" (~99) |
|---|---|---|---|
| Performance | 0.85 | **0.95** | 4 |
| Accessibility | 0.90 | **0.97** | 3 |
| Best Practices | 0.90 | **0.95** | 5 |
| SEO | 0.90 | **0.97** | 3 |

**2. Add per-audit assertions for the specific audits that previously failed,** so a regression in any one of them blocks merges even when the aggregate category score stays above its floor:

- `cumulative-layout-shift` → `maxNumericValue: 0.1` (Lighthouse's "good" boundary; banner was at 0.117)
- `robots-txt` → `error`
- `link-in-text-block` → `error`
- `image-aspect-ratio` → `error`
- `image-size-responsive` → `error`

Two surfaced as warnings rather than errors:

- `unsized-images` → `warn` — cover thumbnails in `static/uploads/` legitimately can't be sized without moving them into `assets/` (out of scope, see #171 discussion).
- `errors-in-console` → `warn` — environment-sensitive (sandbox MITM cert errors flag this; production doesn't).

`presentation-role-conflict` is a Lighthouse 13+ audit and isn't bundled with `@lhci/cli` 0.15.1 yet, so the tightened accessibility floor (0.97) is the safety net for that class of regression.

## Test plan

- [x] `lhci autorun` against local build passes with new config
- [x] Both `warn`-level audits surface in the report without failing CI
- [x] All `error`-level audit IDs verified to exist in the bundled Lighthouse 12.6.1
- [ ] First PR after merge confirms the new floors don't trigger false-positives on production-quality scores

https://claude.ai/code/session_01RgZUX9iuQZMj2qGy3yDFZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgZUX9iuQZMj2qGy3yDFZE)_