### PR TITLE
fix(ci): schedule scan crash on posts missing publishDate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           fail_level: error
+
+  test:
+    name: Script tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run script unit tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ HUGO_SITE_DIR := .
 PUBLIC_DIR := public
 HUGO_VERSION := $(shell cat .hugo-version)
 
-.PHONY: build serve serve-draft clean minify production netlify-deploy netlify-preview netlify-open list version netlify-update netlify-dev netlify-status netlify-logs netlify-init netlify-env netlify-build netlify-build-preview netlify-build-branch netlify-redirects netlify-validate-config deploy-all check-hugo local-setup verify buffer-update humanizer-update shellcheck actionlint lint test vale vale-sync prose email-validate
+.PHONY: build serve serve-draft clean minify production netlify-deploy netlify-preview netlify-open list version netlify-update netlify-dev netlify-status netlify-logs netlify-init netlify-env netlify-build netlify-build-preview netlify-build-branch netlify-redirects netlify-validate-config deploy-all check-hugo local-setup verify buffer-update humanizer-update shellcheck actionlint lint test check vale vale-sync prose email-validate
 
 # Default target
 help:
@@ -56,6 +56,7 @@ help:
 	@echo "  make shellcheck         - Run shellcheck on all shell scripts"
 	@echo "  make actionlint         - Run actionlint on GitHub Actions workflows"
 	@echo "  make lint               - Run shellcheck + actionlint"
+	@echo "  make check              - Run lint + test (pre-commit gate)"
 	@echo "  make vale-sync          - Fetch third-party Vale style packages"
 	@echo "  make vale               - Run Vale prose linter on content/"
 	@echo "  make prose              - Run Vale and print a finding-count summary"
@@ -257,6 +258,10 @@ lint: shellcheck actionlint
 # Run unit tests for scripts
 test:
 	@bash scripts/test-find-promotable-posts.sh
+
+# Pre-commit gate: every static + dynamic check we run in CI.
+# Run this locally before pushing to catch issues before the PR opens.
+check: lint test
 
 # Fetch third-party Vale style packages declared in .vale.ini
 vale-sync:

--- a/content/posts/profiling-python-with-ebpf.md
+++ b/content/posts/profiling-python-with-ebpf.md
@@ -1,8 +1,8 @@
 ---
 title: "Profiling Python with eBPF: A New Frontier in Performance Analysis"
 author: Kemal Akkoyun
-date: 2024-02-12
-publishDate: 2024-02-12
+date: 2024-02-12T00:00:00Z
+publishDate: 2024-02-12T00:00:00Z
 categories:
   - deep-dive
 tags:

--- a/content/posts/profiling-python-with-ebpf.md
+++ b/content/posts/profiling-python-with-ebpf.md
@@ -2,6 +2,7 @@
 title: "Profiling Python with eBPF: A New Frontier in Performance Analysis"
 author: Kemal Akkoyun
 date: 2024-02-12
+publishDate: 2024-02-12
 categories:
   - deep-dive
 tags:

--- a/scripts/find-promotable-posts.sh
+++ b/scripts/find-promotable-posts.sh
@@ -18,13 +18,18 @@ is_draft() {
 }
 
 get_publish_date() {
-  # Extract publishDate from YAML frontmatter, return date portion only (YYYY-MM-DD)
-  grep '^publishDate:' "$1" | head -1 | awk '{print $2}' | tr -d '"' | cut -dT -f1
+  # Extract publishDate from YAML frontmatter, return date portion only (YYYY-MM-DD).
+  # Returns empty (exit 0) when the field is missing — callers must handle that.
+  local line
+  line=$(grep -m1 '^publishDate:' "$1" || true)
+  [ -z "$line" ] && return 0
+  echo "$line" | awk '{print $2}' | tr -d '"' | cut -dT -f1
 }
 
 file_added_date() {
-  # Date file was first added to git (for dedup between push and cron triggers)
-  git log --diff-filter=A --format=%cs -- "$1" | head -1
+  # Date file was first added to git (for dedup between push and cron triggers).
+  # Returns empty (exit 0) when git has no record of the file.
+  git log --diff-filter=A --format=%cs -- "$1" 2>/dev/null | awk 'NR==1{print; exit}'
 }
 
 validate_post() {

--- a/scripts/test-find-promotable-posts.sh
+++ b/scripts/test-find-promotable-posts.sh
@@ -47,6 +47,10 @@ setup_repo() {
   git init -q
   git config user.email "test@test.com"
   git config user.name "Test"
+  # Disable commit signing inherited from the user's global gitconfig — the
+  # tests don't need signed commits and signing breaks in sandboxed CI runners.
+  git config commit.gpgsign false
+  git config tag.gpgsign false
   mkdir -p content/posts
   touch content/posts/.gitkeep
   git add content/posts/.gitkeep
@@ -214,6 +218,30 @@ assert_empty "schedule: skips draft even when publishDate matches today" "$resul
 
 result=$(with_repo _sched_dedup)
 assert_eq   "schedule: dedup skips today-added, promotes yesterday-committed" "content/posts/scheduled.md" "$result"
+
+_sched_no_pub_alone() {
+  # Legacy post with no publishDate — schedule scan must not crash on it.
+  # Regression for run 25847187011: get_publish_date used to fail under
+  # `set -euo pipefail` when the frontmatter had no publishDate field.
+  make_post_no_date "content/posts/legacy.md"
+  commit_at "content/posts/legacy.md" "$YESTERDAY"
+  run_find schedule
+}
+_sched_no_pub_mixed() {
+  # Same legacy file alongside a legitimate today-dated post — the today post
+  # must still be promoted, proving the no-pub file is skipped, not blocking.
+  make_post_no_date "content/posts/legacy.md"
+  commit_at         "content/posts/legacy.md" "$YESTERDAY"
+  make_post         "content/posts/today.md" "$TODAY"
+  commit_at         "content/posts/today.md" "$YESTERDAY"
+  run_find schedule
+}
+
+result=$(with_repo _sched_no_pub_alone)
+assert_empty "schedule: legacy post with missing publishDate does not crash the scan" "$result"
+
+result=$(with_repo _sched_no_pub_mixed)
+assert_eq    "schedule: today-dated post is promoted even when a no-pub legacy post coexists" "content/posts/today.md" "$result"
 
 # ── manual mode ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes a regression where the schedule scan would crash when encountering posts without a `publishDate` field in their frontmatter. The `get_publish_date()` function was failing under `set -euo pipefail` when the field was missing. Also hardens `file_added_date()` to gracefully handle missing git records.

## Changes

- **`scripts/find-promotable-posts.sh`**
  - Modified `get_publish_date()` to explicitly handle missing `publishDate` fields by returning empty (exit 0) instead of failing
  - Changed `file_added_date()` to suppress stderr and use `awk` for safer single-line extraction
  - Updated function comments to document empty-return behavior for callers

- **`scripts/test-find-promotable-posts.sh`**
  - Added git config to disable commit/tag signing in test repos (prevents CI sandbox failures)
  - Added two new regression test cases:
    - `_sched_no_pub_alone`: Verifies scan doesn't crash on legacy post with missing `publishDate`
    - `_sched_no_pub_mixed`: Verifies today-dated posts are still promoted when legacy posts coexist

- **`.github/workflows/lint.yml`**
  - Added `test` job to run `make test` in CI

- **`Makefile`**
  - Added `check` target as pre-commit gate combining `lint` and `test`
  - Updated `.PHONY` declaration and help text

- **`content/posts/profiling-python-with-ebpf.md`**
  - Added missing `publishDate: 2024-02-12` field (aligns with content conventions)

## Implementation Details

The core fix uses `grep -m1 ... || true` to safely extract the publishDate line, then checks if the result is empty before processing. This allows the function to return cleanly when the field is absent, letting callers decide how to handle it (typically skipping the post). The test suite now validates both the crash fix and that legitimate posts are still promoted when legacy posts are present.

https://claude.ai/code/session_01DATZGGRvoLuyvEWakNr5C1