### PR TITLE
Update now, about, and uses pages to reflect agentic AI focus

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -34,9 +34,9 @@ My work was deeply rooted in **profiling, eBPF, performance engineering, time-se
 
 In my free time, I'm a **tinkerer**—I open things up, inspect what's inside, and fix them. I'm also a **bookworm, a mechanical keyboard and LEGO builder, a single malt taster, and a coffee drinker in training** (peer pressure).
 
-I enjoy **sci-fi and fantasy literature, board games, and programming fun side projects** (from Raspberry Pi cluster experiments to Flipper Zero hardware hacking). I'm passionate about **traveling, cooking vegan and vegetarian dishes**, and constantly **challenging myself to learn new languages**—one day, I hope to become a proper polyglot.
+I enjoy **sci-fi and fantasy literature, board games, and programming fun side projects** (from Raspberry Pi cluster experiments to running local LLMs on cheap hardware, with multi-agent flows as my current obsession). I'm passionate about **traveling, cooking vegan and vegetarian dishes**, and constantly **challenging myself to learn new languages**—one day, I hope to become a proper polyglot.
 
-**Gravel cycling** is my escape. I'm dreaming of camping and bikepacking adventures—trips I want to take with my son when he's grown up enough to join me on two wheels.
+**Gravel cycling** is my escape, with **HIIT boot camps, Hyrox, and indoor cycling** filling the gaps when life gets in the way. I'm dreaming of camping and bikepacking adventures, trips I want to take with my son when he's grown up enough to join me on two wheels.
 
 As an **angel investor**, I've had the privilege of investing in two promising companies, helping support innovation and growth in the tech space.
 
@@ -44,7 +44,7 @@ One of my long-term goals is **early retirement**, spending most of my time outd
 
 #### Home
 
-I currently live in **Berlin, Germany**, with my beloved significant other, **Rüya**, and our one-year-old son, **Atlas Robin**. Our home is often filled with toys and creative projects. Though we recently lost our beloved dog, she lives on in spirit—and through the tattoo on my left forearm.
+I currently live in **Berlin, Germany**, with my beloved significant other, **Rüya**, and our son, **Atlas Robin**. Our home is often filled with toys and creative projects. Though we recently lost our beloved dog, she lives on in spirit—and through the tattoo on my left forearm.
 
 ### More
 

--- a/content/about.md
+++ b/content/about.md
@@ -34,7 +34,7 @@ My work was deeply rooted in **profiling, eBPF, performance engineering, time-se
 
 In my free time, I'm a **tinkerer**—I open things up, inspect what's inside, and fix them. I'm also a **bookworm, a mechanical keyboard and LEGO builder, a single malt taster, and a coffee drinker in training** (peer pressure).
 
-I enjoy **sci-fi and fantasy literature, board games, and programming fun side projects** (from Raspberry Pi cluster experiments to running local LLMs on cheap hardware, with multi-agent flows as my current obsession). I'm passionate about **traveling, cooking vegan and vegetarian dishes**, and constantly **challenging myself to learn new languages**—one day, I hope to become a proper polyglot.
+I enjoy **sci-fi and fantasy literature, board games, and programming fun side projects** (from Raspberry Pi cluster experiments to running local LLMs on cheap hardware, with multi-agent flows as my current obsession). I'm passionate about **traveling** and constantly **challenging myself to learn new languages**—one day, I hope to become a proper polyglot.
 
 **Gravel cycling** is my escape, with **HIIT boot camps, Hyrox, and indoor cycling** filling the gaps when life gets in the way. I'm dreaming of camping and bikepacking adventures, trips I want to take with my son when he's grown up enough to join me on two wheels.
 

--- a/content/now.md
+++ b/content/now.md
@@ -21,11 +21,13 @@ Currently focused on Go runtime and compiler internals, building AST manipulatio
 
 Deep in agentic engineering as a hobby. Building complex multi-agent flows and finding their limits: what these systems do well, and what falls over once you push past the demo.
 
-Day-to-day I live inside [Claude Code](https://claude.com/code) and [Pie](https://pi.dev), the two agentic coding environments doing most of the heavy lifting. Still poking at LLM internals on the side.
+Day-to-day I live inside [Claude Code](https://claude.com/code) and [pi](https://pi.dev), the two agentic coding environments doing most of the heavy lifting.
+
+Still focused on writing, blogging, engineering leadership, and the internals of LLMs. Exploring how these tools work under the hood and how to build better systems with them.
 
 ## Hobby Tech
 
-Running local LLMs on my Raspberry Pi cluster. Seeing how much you can squeeze out of cheap hardware and small models.
+Running local LLMs on my Raspberry Pi cluster. I'm convinced Raspberry Pi plus local compute is where a lot of the future of LLMs actually lives, and I want to see how much you can squeeze out of cheap hardware and small models.
 
 ## Family & Life
 

--- a/content/now.md
+++ b/content/now.md
@@ -19,22 +19,22 @@ Currently focused on Go runtime and compiler internals, building AST manipulatio
 
 ## Learning & Exploration
 
-Focused on writing, blogging, engineering leadership, and the internals of LLMs. Exploring how these tools work under the hood and how to build better systems with them.
+Deep in agentic engineering as a hobby. Building complex multi-agent flows and finding their limits: what these systems do well, and what falls over once you push past the demo.
 
-Experimenting with Claude Code, Claude Desktop, and MCPs to fully automate my Personal Knowledge Management on top of Obsidian.
+Day-to-day I live inside [Claude Code](https://claude.com/code) and [Pie](https://pi.dev), the two agentic coding environments doing most of the heavy lifting. Still poking at LLM internals on the side.
 
 ## Hobby Tech
 
-Showing some love to my Raspberry Pi cluster and Flipper Zero. Small projects, big fun.
+Running local LLMs on my Raspberry Pi cluster. Seeing how much you can squeeze out of cheap hardware and small models.
 
 ## Family & Life
 
-Based in Berlin with my partner and our son.
+Based in Berlin with my partner and our son. The boy sets the schedule, which is fair. Whatever free time is left collapses into three buckets: read, exercise, write.
 
-Gravel cycling whenever I can. Dreaming of camping and bikepacking trips—something I want to do with my boy when he's grown up enough. For now, prioritizing outdoor time and sleep.
+On the movement side: gravel cycling when the weather and the calendar agree, plus HIIT boot camps, Hyrox, and indoor cycling on the trainer for the in-between days. Still dreaming of bikepacking trips with my boy once he's old enough for two wheels.
 
 ## Reading & Writing
 
-Reading a mix of systems papers, engineering leadership books, and sci-fi. Check my [reading page](/reading/) for current books.
+Reading a mix of systems papers, engineering leadership books, and sci-fi. The to-read pile and the article backlog keep growing faster than I burn through them; check my [reading page](/reading/) for what's currently in rotation.
 
-Notes and insights land in the **[notes](/notes/)** section when useful.
+The read-then-write loop now feeds [The Unwind](/newsletter/the-unwind/), my roughly-weekly newsletter of links and notes. Other notes and insights still land in the **[notes](/notes/)** section when useful.

--- a/content/uses.md
+++ b/content/uses.md
@@ -36,7 +36,7 @@ Updated occasionally; this is what I actually use day-to-day.
 ## Editors
 
 - [Claude Code](https://claude.com/code) for most work
-- [Pie](https://pi.dev) as my agentic coding environment
+- [pi](https://pi.dev) as my agentic coding environment
 - Neovim for quick edits and terminal workflows
 
 ## Languages & Toolchains
@@ -62,7 +62,7 @@ Updated occasionally; this is what I actually use day-to-day.
 
 - **Raspberry Pi cluster**: Home lab for experiments and learning
 - **Local LLMs**: Running small models on the Pi cluster, seeing how far cheap hardware goes
-- **Multi-agent flows**: Building agentic systems with [Claude Code](https://claude.com/code) and [Pie](https://pi.dev), poking at where they break
+- **Multi-agent flows**: Building agentic systems with [Claude Code](https://claude.com/code) and [pi](https://pi.dev), poking at where they break
 
 ## Cycling
 

--- a/content/uses.md
+++ b/content/uses.md
@@ -35,7 +35,8 @@ Updated occasionally; this is what I actually use day-to-day.
 
 ## Editors
 
-- Cursor / VS Code for most work
+- [Claude Code](https://claude.com/code) for most work
+- [Pie](https://pi.dev) as my agentic coding environment
 - Neovim for quick edits and terminal workflows
 
 ## Languages & Toolchains
@@ -60,7 +61,8 @@ Updated occasionally; this is what I actually use day-to-day.
 ## Hobby Tech
 
 - **Raspberry Pi cluster**: Home lab for experiments and learning
-- **Flipper Zero**: Hardware hacking and security research
+- **Local LLMs**: Running small models on the Pi cluster, seeing how far cheap hardware goes
+- **Multi-agent flows**: Building agentic systems with [Claude Code](https://claude.com/code) and [Pie](https://pi.dev), poking at where they break
 
 ## Cycling
 


### PR DESCRIPTION
## Summary

Updated personal pages (`now.md`, `about.md`, `uses.md`) to reflect a shift in focus toward agentic engineering and multi-agent AI systems, with corresponding updates to hobby tech interests and daily tooling.

## Key Changes

- **now.md**: Repositioned agentic engineering as primary learning focus; elevated Claude Code and pi as day-to-day environments; reframed Raspberry Pi hobby from general tinkering to running local LLMs on cheap hardware; expanded life section with concrete time-allocation details (read, exercise, write) and movement activities (HIIT, Hyrox, indoor cycling); added mention of The Unwind newsletter as output for the read-then-write loop

- **about.md**: Replaced Flipper Zero hardware hacking with local LLMs and multi-agent flows as hobby tech interests; expanded cycling section to include HIIT boot camps, Hyrox, and indoor cycling; removed cooking reference; updated family section to remove "one-year-old" age descriptor (now outdated)

- **uses.md**: Replaced Cursor/VS Code with Claude Code as primary editor; added pi as secondary agentic coding environment; replaced Flipper Zero with local LLMs and multi-agent flows in hobby tech section; added links to Claude Code and pi

## Implementation Details

Changes maintain the existing structure and tone of each page while providing more current and specific information about tools, interests, and time allocation. All updates are factual reflections of current focus areas rather than aspirational content.

https://claude.ai/code/session_01QheJSHCNp9oy2EE3dNDGu3