### PR TITLE
Include newsletter issues in home RSS feed for cross-promotion

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -55,6 +55,12 @@
 {{- $pages = $pctx.Pages }}
 {{- end }}
 {{- $pages = where $pages "Params.hiddenInRss" "!=" true -}}
+{{- /* Sort after the union+filter so the home feed (which merges
+       mainSections with newsletter pages) is globally ordered by
+       publish date, not partitioned. Also matters before applying
+       $limit below: without this, a full mainSections slice could
+       push newsletter issues past the cutoff. */ -}}
+{{- $pages = sort $pages "PublishDate" "desc" -}}
 {{- $limit := site.Config.Services.RSS.Limit }}
 {{- if ge $limit 1 }}
 {{- $pages = $pages | first $limit }}
@@ -100,15 +106,21 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      {{- /* For newsletter items, emit the full rendered HTML body in
-             <description> so Hakanai Broadcast's {{description}}
-             Mustache var (which maps to RSS <description>) carries the
-             full article into the email. Hakanai doesn't expose
-             <content:encoded> as a separate var. This only applies to
-             per-publication feeds (one email per issue); on the home
-             digest feed newsletter items fall through to the
-             summary-only branch like every other section so they don't
-             splat full issue bodies into the digest. */ -}}
+      {{- /* For newsletter items on their own per-publication feed,
+             emit the full rendered HTML body in <description> so
+             Hakanai Broadcast's {{description}} Mustache var (which
+             maps to RSS <description>) carries the full article into
+             the one-email-per-issue send. Hakanai doesn't expose
+             <content:encoded> as a separate var, so the trick is
+             scoped to <description> only.
+
+             On the home feed newsletter items fall through to the
+             default branch, which mirrors how posts/notes/talks are
+             rendered: summary in <description>, and (because
+             site.Params.ShowFullTextinRSS is true) full body in
+             <content:encoded> below. That keeps Hakanai's main-campaign
+             digest summary-only via {{description}} while generic RSS
+             readers see full text consistently across all sections. */ -}}
       {{- if and (eq .Section "newsletter") (not $.IsHome) }}
       <description>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</description>
       {{- else }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -12,11 +12,13 @@
      Lastmod / PublishDate, falling back to build time when the feed
      has no items yet.
 
-  2. On the home feed only, filter to mainSections so newsletter
-     issues (and other non-blog content) don't leak into /index.xml.
-     The home feed stays a blog-and-notes-and-talks feed; each
-     newsletter publication has its own dedicated section feed at
-     /newsletter/<slug>/index.xml that its Hakanai campaign polls.
+  2. On the home feed, include mainSections plus newsletter issues
+     so the main Hakanai campaign can cross-promote them in its
+     digest. Per-publication feeds at /newsletter/<slug>/index.xml
+     remain the source of truth that each publication's campaign
+     polls; the home feed shows newsletter items as summary-only
+     entries (see the description-handling branch below) so they
+     don't splat full issue bodies into the digest.
 
   The template otherwise mirrors PaperMod's upstream output.
 */ -}}
@@ -44,7 +46,9 @@
 {{- if .IsHome }}{{ $pctx = site }}{{ end }}
 {{- $pages := slice }}
 {{- if .IsHome }}
-{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $main := where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $newsletter := where site.RegularPages "Section" "newsletter" }}
+{{- $pages = $main | union $newsletter }}
 {{- else if .IsSection }}
 {{- $pages = $pctx.RegularPages }}
 {{- else }}
@@ -100,9 +104,12 @@
              <description> so Hakanai Broadcast's {{description}}
              Mustache var (which maps to RSS <description>) carries the
              full article into the email. Hakanai doesn't expose
-             <content:encoded> as a separate var. Other sections keep
-             the default summary-only description. */ -}}
-      {{- if eq .Section "newsletter" }}
+             <content:encoded> as a separate var. This only applies to
+             per-publication feeds (one email per issue); on the home
+             digest feed newsletter items fall through to the
+             summary-only branch like every other section so they don't
+             splat full issue bodies into the digest. */ -}}
+      {{- if and (eq .Section "newsletter") (not $.IsHome) }}
       <description>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</description>
       {{- else }}
       <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>

--- a/templates/emails/standard.mjml
+++ b/templates/emails/standard.mjml
@@ -41,6 +41,28 @@
     </mj-section>
     {{/articles}}
 
+    <mj-section background-color="#FFFFFF" padding="8px 28px 24px">
+      <mj-column>
+        <mj-divider border-color="#EEEEEE" border-width="2px" padding="8px 0 16px" />
+        <mj-text mj-class="article-title" align="center">Want more, more often?</mj-text>
+        <mj-text mj-class="article-body" align="center">
+          <a href="https://kakkoyun.me/newsletter/the-unwind/">The Unwind</a>
+          is a hand-curated, roughly-weekly dispatch of links and notes from what I&rsquo;ve read and built lately.
+        </mj-text>
+        <mj-button
+          href="https://kakkoyun.me/newsletter/the-unwind/"
+          background-color="#1E1E1E"
+          color="#FFFFFF"
+          font-size="15px"
+          font-weight="600"
+          inner-padding="12px 22px"
+          border-radius="4px"
+          padding="12px 0 0">
+          Subscribe to The Unwind &rarr;
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
     <mj-section background-color="#FFFFFF" padding="12px 28px 24px">
       <mj-column>
         <mj-divider border-color="#EEEEEE" border-width="2px" padding="8px 0 16px" />


### PR DESCRIPTION
## Summary

Updates the home RSS feed to include newsletter issues alongside blog content, enabling the main Hakanai campaign to cross-promote them in its digest. Per-publication feeds remain the authoritative source for each newsletter's campaign.

## Changes

**RSS Feed Template (`layouts/_default/rss.xml`)**
- Modified home feed filtering to include both `mainSections` and newsletter items (instead of excluding newsletters entirely)
- Updated the description-handling logic to only include full article bodies for newsletter items in per-publication feeds (`not $.IsHome`), ensuring newsletter items appear as summary-only entries in the home digest to prevent full issue bodies from splatting into the email
- Updated inline documentation to reflect the new cross-promotion strategy

**Email Template (`templates/emails/standard.mjml`)**
- Added a new promotional section between articles and footer that highlights "The Unwind" newsletter with a subscription call-to-action
- Includes divider, descriptive text, and a styled button linking to the newsletter signup page

## Implementation Details

The RSS feed change uses Hugo's `union` function to combine two page slices:
- `$main`: pages filtered by `mainSections` (blog, notes, talks)
- `$newsletter`: pages from the newsletter section

The conditional `{{if and (eq .Section "newsletter") (not $.IsHome)}}` ensures full content encoding only applies to dedicated per-publication feeds, maintaining the home feed's summary-only behavior for newsletters while preserving full content for per-publication campaigns that poll their dedicated feeds.

https://claude.ai/code/session_01Cf8sgsQt4nBqxEiSG3MCYp