### PR TITLE
ci: add merge-schedule-action for series-PR sequencing

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -1,0 +1,64 @@
+name: Merge Schedule
+
+# Auto-merge PRs whose description contains a `/schedule YYYY-MM-DD` (or
+# ISO 8601) directive once that date has passed.
+#
+# Why this exists when Hugo already handles publishDate scheduling:
+# Series posts cross-reference each other (e.g. part 2 links back to part 1).
+# Both must live on master in the correct order before Hugo's daily rebuild
+# picks them up — otherwise part 2 ships with a broken internal link until
+# the next deploy. This action lets us land a series as a queue of PRs that
+# merge in the intended sequence, while Hugo's publishDate keeps the posts
+# invisible to readers until their scheduled day.
+#
+# Cadence: every 6h (we publish ~one post/day, so faster polling buys nothing).
+#
+# Usage: add a line at the bottom of the PR description, e.g.:
+#   /schedule 2026-06-08
+#   /schedule 2026-06-08T07:00:00Z      # ISO 8601, timezone-safe
+#   /schedule                            # merge on the next cron tick
+#
+# Branch protection note: this action uses GITHUB_TOKEN, which respects
+# branch protection rules. If required reviews ever block auto-merge,
+# create a GitHub App per the action's README and inject its token instead.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+  schedule:
+    # Every 6 hours at :30 — offset from main.yml (00:00) and
+    # promote-post.yml (06:00), and clear of GitHub's on-the-hour cron rush.
+    - cron: "30 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write # merge the PR
+  pull-requests: write # set status, comment, label
+  statuses: read # required when require_statuses_success: true
+  checks: read
+
+jobs:
+  merge_schedule:
+    name: Merge scheduled PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip on PRs from forks: the action ignores them anyway (and GITHUB_TOKEN
+    # is read-only for forks), but skipping early keeps the Actions tab tidy.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: gr2m/merge-schedule-action@a9b6ddcf1282dfd66907bda8e7941dff59f03bad # v2.7.0
+        with:
+          merge_method: squash
+          # Default UTC. Use ISO 8601 dates in the PR body
+          # (e.g. /schedule 2026-06-08T07:00:00Z) for timezone-safe scheduling.
+          time_zone: "UTC"
+          # Wait for build.yml + links.yml + prose.yml to finish green before
+          # merging. Series posts in particular need a clean build first.
+          require_statuses_success: "true"
+          automerge_fail_label: "merge-schedule-failed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ GitHub Actions workflows:
 - **`prose-review.yml`** -- Claude prose review. Label-triggered only (apply `prose-review` to fire). Reads `REVIEW.md` and the `kemal-voice` skill. Advisory.
 - **`claude-code-review.yml`** -- Generic code reviewer. Label-triggered only (apply `claude-review` to fire). Advisory.
 - **`claude.yml`** -- `@claude` mention handler.
+- **`merge-schedule.yml`** -- Auto-merges PRs containing a `/schedule YYYY-MM-DD` (or ISO 8601) directive in the description once the scheduled time has passed. Runs every 6 hours at `:30` plus on `pull_request` events. Used for **series posts** that cross-link each other: Hugo's `publishDate` controls visibility, but the PRs themselves must land on master in the intended order so internal links resolve. `require_statuses_success: true` waits for build + links + prose checks to go green before merging. Add `/schedule 2026-06-08T07:00:00Z` at the bottom of the PR description (ISO 8601 is timezone-safe). Failed merges get the `merge-schedule-failed` label.
 
 ## Key Integrations
 


### PR DESCRIPTION
## Why this exists

Hugo's `publishDate` already keeps a post invisible until its scheduled day. So why add this?

**Series posts cross-reference each other.** Part 2 links back to part 1. If both PRs are open and part 2 lands on `master` before part 1, part 2 ships with a broken internal link until the next deploy. Or worse — if they're staged for different days but I merge them in the wrong order, the cross-reference resolves to a 404 between deploys.

`merge-schedule-action` lets me open part 1, part 2, part 3 as a queue and have them merge in order on their target dates. Hugo's `publishDate` still controls reader visibility — this just controls when the source files land on `master`.

Cadence: every 6h. We publish ~one post/day; faster polling buys nothing.

## How to use

Add a line at the bottom of the PR description, for example:

- `` `/schedule 2026-06-08T07:00:00Z` `` — ISO 8601, timezone-safe (recommended)
- `` `/schedule 2026-06-08` `` — date-only, treated as UTC midnight
- `` `/schedule` `` — merge on the next cron tick

Failed merges get the `merge-schedule-failed` label.

> **Note** on PR-description syntax: the action's directive parser uses the regex `/(^|\n)\/schedule/`, which doesn't respect markdown code fences. Any line in the PR body that begins with `/schedule ...` is treated as a directive — even inside a triple-backtick block. So examples in PR bodies (like the ones above) must be in list items or otherwise have leading characters before `/schedule`. This PR self-tripped that gotcha on the first revision; it's now fixed.

## Configuration choices

| Setting | Value | Why |
|---|---|---|
| `merge_method` | `squash` | Matches recent `(#N)`-style history on `master` |
| `require_statuses_success` | `true` | Series PRs only merge once `build.yml` + `links.yml` + `prose.yml` go green. A broken internal link in a series would otherwise slip through. |
| `time_zone` | `UTC` | Default. Use ISO 8601 in the PR body for timezone-safe scheduling. |
| `automerge_fail_label` | `merge-schedule-failed` | Visibility in the PR list when a scheduled merge couldn't go through |
| Cron | `30 */6 * * *` | Every 6h at `:30` — offset from `main.yml` (00:00) and `promote-post.yml` (06:00), and clear of GitHub's on-the-hour cron rush |
| Pinning | `gr2m/merge-schedule-action@a9b6ddcf...` `# v2.7.0` | SHA-pinned per repo convention; Renovate auto-tracks via `config:recommended` |

## Best-practices audit

- [x] Action pinned by SHA, not tag
- [x] Explicit `permissions:` block with minimum scopes (`contents: write`, `pull-requests: write`, `statuses: read`, `checks: read`) — see the Copilot-review reply below for why `issues: write` is **not** needed despite the action calling `octokit.rest.issues.*`
- [x] `timeout-minutes: 5`
- [x] Fork-PR guard via `if:` (defense-in-depth; action ignores forks too)
- [x] `workflow_dispatch` for manual debugging
- [x] No `pull_request_target` (avoids the privileged-context footgun)
- [x] Cron offset from existing workflow crons (no double-firing)
- [x] `actionlint` (the same one `lint.yml` runs in CI) exits 0
- [x] Renovate already covers the new action via existing config

## Token decision

Uses the default `GITHUB_TOKEN`. No PAT or GitHub App needed:
- Branch protection on `master` has no required-reviewer rule, so `GITHUB_TOKEN` can merge.
- The known cascade-trigger limitation (`GITHUB_TOKEN`-emitted events don't fire other workflows) is acceptable: Netlify deploys regardless (it watches the repo directly), and `promote-post.yml`'s 6 AM UTC cron picks up auto-merged posts the next morning.

If we ever need immediate social promotion on auto-merge, swap in a fine-grained PAT with `Contents: write`, `Pull requests: write`, `Commit statuses: read`, `Checks: read`, `Metadata: read` (scoped to this repo only).

## Local CI verification

All `lint.yml` checks pass locally:

| Check | Result |
|---|---|
| `actionlint` on all workflows | exit 0 |
| `shellcheck` on `scripts/*.sh` | exit 0 |
| `make test` (script unit tests) | 20/20 passed |
| `yamllint` (sanity) | exit 0 |

## Follow-up suggestion (out of scope for this PR)

Repo Settings → Actions → General → Workflow permissions is set to **Read and write**. Best practice is **Read repository contents and packages permissions** (read-only by default) — every workflow in this repo already declares its own `permissions:` block, so flipping the default to read-only tightens security with zero functional impact. Worth a separate one-click change in the repo settings UI.

## Testing

To verify end-to-end after merge: open a throwaway PR with a `/schedule` directive set a few minutes in the future (use a list-item or otherwise non-line-start syntax to avoid this PR's gotcha) and watch the next cron tick land it. Or trigger `workflow_dispatch` manually from the Actions tab.
