### PR TITLE
Remove push trigger from promotion pipeline

### DIFF
--- a/.github/workflows/promote-post.yml
+++ b/.github/workflows/promote-post.yml
@@ -40,11 +40,17 @@ jobs:
 
       - name: Find promotable posts
         id: find
+        # POST_PATH is passed via env, not interpolated into the script body:
+        # `${{ ... }}` is expanded before bash runs, so a dispatch input containing
+        # $(...) or backticks would otherwise execute on the runner (script injection).
+        # As an env var it reaches bash as opaque data.
+        env:
+          POST_PATH: ${{ github.event.inputs.post_path }}
         run: |
           chmod +x scripts/find-promotable-posts.sh
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.post_path }}" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$POST_PATH" ]; then
             # Manual run targeting one specific post (skips the date check).
-            POSTS=$(scripts/find-promotable-posts.sh manual "${{ github.event.inputs.post_path }}")
+            POSTS=$(scripts/find-promotable-posts.sh manual "$POST_PATH")
           else
             # Daily cron, or a manual run with no post_path: promote everything due today.
             POSTS=$(scripts/find-promotable-posts.sh schedule)

--- a/.github/workflows/promote-post.yml
+++ b/.github/workflows/promote-post.yml
@@ -1,17 +1,14 @@
 name: Promote New Post
 
 on:
-  push:
-    branches: [master]
-    paths: ['content/posts/**']
   schedule:
     # Run every day at 6 AM UTC — catches scheduled posts on their publish day
     - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       post_path:
-        description: 'Path to post file (e.g., content/posts/my-post.md)'
-        required: true
+        description: 'Path to a specific post (content/posts/my-post.md). Leave blank to promote everything due today.'
+        required: false
         type: string
       dry_run:
         description: 'Install a stub buffer-cli that echoes instead of posting'
@@ -25,6 +22,11 @@ jobs:
   # live on its publish day regardless of whether this promotion cron fires.
   # Promotion here instead guards on liveness (see "Verify posts are live"
   # below): it will not post a social link to a page that is not yet reachable.
+  #
+  # Triggers: the daily cron promotes posts on their publish day; workflow_dispatch
+  # is the manual "promote now" button (one post via post_path, or everything due
+  # today when left blank). There is no push trigger — claude-code-action rejects
+  # the push event type ("Unsupported event type: push").
   promote:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -34,19 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          fetch-depth: 0  # Full history needed for git log in schedule/dedup mode
           submodules: false
 
       - name: Find promotable posts
         id: find
         run: |
           chmod +x scripts/find-promotable-posts.sh
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.post_path }}" ]; then
+            # Manual run targeting one specific post (skips the date check).
             POSTS=$(scripts/find-promotable-posts.sh manual "${{ github.event.inputs.post_path }}")
-          elif [ "${{ github.event_name }}" = "schedule" ]; then
-            POSTS=$(scripts/find-promotable-posts.sh schedule)
           else
-            POSTS=$(scripts/find-promotable-posts.sh push)
+            # Daily cron, or a manual run with no post_path: promote everything due today.
+            POSTS=$(scripts/find-promotable-posts.sh schedule)
           fi
 
           if [ -z "$POSTS" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,18 +186,23 @@ The wrapper pattern means the upstream skill's `buffer get-account` / `buffer po
 
 ### Social Media Promotion Pipeline
 
-Automated via `.github/workflows/promote-post.yml` with three triggers:
+Automated via `.github/workflows/promote-post.yml` with two triggers:
 
-- **Push**: promotes newly added posts when `publishDate <= today`
-- **Nightly cron (6 AM UTC)**: promotes scheduled posts on their publish day
-- **Manual dispatch**: re-promote or promote any specific post
+- **Nightly cron (6 AM UTC)**: promotes posts on their publish day (`publishDate == today`)
+- **Manual dispatch**: the "promote now" button — give a `post_path` to promote one
+  specific post, or leave it blank to promote everything due today
+
+There is **no push trigger**: `claude-code-action` rejects the `push` event type
+("Unsupported event type: push"), so promotion runs only on supported automation
+events (`schedule`, `workflow_dispatch`). A post merged on its publish day *after*
+the 6 AM cron has run won't be auto-promoted that day — use the manual dispatch to
+promote it immediately.
 
 Promotion does **not** rebuild the site — publishing is owned by `deploy-scheduled.yml`
 (00:10 UTC). The 6 AM promotion cron is deliberately later so the post is already live.
 Before posting, a **liveness guard** (`Verify posts are live`) maps each candidate to its
 public URL (`content/posts/<slug>.md` → `/posts/<slug>/`) and polls it; a post that is not
-reachable is dropped with a warning, so promotion never posts a link to a 404 (and push-mode
-promotion waits out an in-flight Netlify deploy instead of racing it).
+reachable is dropped with a warning, so promotion never posts a link to a 404.
 
 All date/draft validation is deterministic bash in `scripts/find-promotable-posts.sh`.
 Claude handles only the creative work: reading the post, crafting messages, posting to Buffer.
@@ -209,9 +214,6 @@ Two skills shape the writing and are wired into both the local command and the C
 
 - **`kemal-voice`** (`.claude/skills/kemal-voice/SKILL.md`) — author voice, banned vocabulary, formulaic openers, patterns to scrutinize. Applied while drafting.
 - **`humanizer`** (`.claude/skills/humanizer/SKILL.md`) — AI-pattern detector from [blader/humanizer](https://github.com/blader/humanizer), vendored as a git submodule at `tools/humanizer/` with `.claude/skills/humanizer` as a symlink. Applied as a revision pass after drafting. The CI workflow initialises just this submodule (`tools/humanizer`) before the action runs; sync locally with `make humanizer-update`.
-
-Dedup: when a post is pushed with today's `publishDate`, the push trigger promotes it.
-The nightly cron skips posts added to git today (detected via `git log --diff-filter=A`).
 
 Local: `/project:promote-post content/posts/<slug>.md` in any Claude Code session.
 

--- a/scripts/find-promotable-posts.sh
+++ b/scripts/find-promotable-posts.sh
@@ -3,14 +3,13 @@
 # All date/draft logic is deterministic — no AI involved.
 #
 # Usage:
-#   find-promotable-posts.sh push          # Push trigger: newly added, publishable today
-#   find-promotable-posts.sh schedule      # Cron trigger: any post with publishDate == today (deduped)
+#   find-promotable-posts.sh schedule      # Cron/manual: any post with publishDate == today
 #   find-promotable-posts.sh manual <path> # Manual: validate single post (skip date check)
 #
 # Output: newline-separated list of promotable post paths (empty = nothing to promote)
 set -euo pipefail
 
-MODE="${1:-push}"
+MODE="${1:-schedule}"
 TODAY=$(date -u +%Y-%m-%d)
 
 frontmatter() {
@@ -34,12 +33,6 @@ get_publish_date() {
   line=$(frontmatter "$1" | grep -m1 '^publishDate:' || true)
   [ -z "$line" ] && return 0
   echo "$line" | awk '{print $2}' | tr -d '"' | cut -dT -f1
-}
-
-file_added_date() {
-  # Date file was first added to git (for dedup between push and cron triggers).
-  # Returns empty (exit 0) when git has no record of the file.
-  git log --diff-filter=A --format=%cs -- "$1" 2>/dev/null | awk 'NR==1{print; exit}'
 }
 
 validate_post() {
@@ -78,19 +71,8 @@ validate_post() {
 }
 
 case "$MODE" in
-  push)
-    # Only newly added files in this commit
-    posts=$(git diff --diff-filter=A --name-only HEAD~1 HEAD -- 'content/posts/*.md' 2>/dev/null || true)
-    while IFS= read -r post; do
-      [ -z "$post" ] && continue
-      if validate_post "$post"; then
-        echo "$post"
-      fi
-    done <<< "$posts"
-    ;;
-
   schedule)
-    # Scan ALL posts for publishDate == today, with dedup
+    # Scan ALL posts for publishDate == today
     for post in content/posts/*.md; do
       [ -f "$post" ] || continue
 
@@ -106,13 +88,6 @@ case "$MODE" in
 
       if skip_promotion "$post"; then
         echo "SKIP $post — promote: false" >&2
-        continue
-      fi
-
-      # Dedup: if file was added today, push trigger already promoted it
-      add_date=$(file_added_date "$post")
-      if [ "$add_date" = "$TODAY" ]; then
-        echo "SKIP $post — added today, already promoted by push trigger" >&2
         continue
       fi
 

--- a/scripts/posts-publishing-today.sh
+++ b/scripts/posts-publishing-today.sh
@@ -8,9 +8,8 @@
 # is live. A today-dated post that becomes reachable does prove it.
 #
 # This is intentionally separate from find-promotable-posts.sh: that filters for
-# *promotion* (honours `promote: false`, dedups against the push trigger). For a
-# *publish* check we want every today-dated, non-draft post, including ones opted
-# out of social promotion.
+# *promotion* (honours `promote: false`). For a *publish* check we want every
+# today-dated, non-draft post, including ones opted out of social promotion.
 #
 # Output: newline-separated content/posts/*.md paths (empty = nothing due today).
 #

--- a/scripts/test-find-promotable-posts.sh
+++ b/scripts/test-find-promotable-posts.sh
@@ -174,51 +174,6 @@ with_repo() {
   return "$rc"
 }
 
-# ── push mode ─────────────────────────────────────────────────────────────────
-
-echo "── push mode ──────────────────────────────────────────"
-
-_push_today()   { make_post "content/posts/new.md" "$TODAY";     commit_at "content/posts/new.md" "$TODAY";     run_find push; }
-_push_future()  { make_post "content/posts/fut.md" "$TOMORROW";  commit_at "content/posts/fut.md" "$TODAY";     run_find push; }
-_push_draft()   { make_post "content/posts/d.md"   "$TODAY" true; commit_at "content/posts/d.md"  "$TODAY";     run_find push; }
-_push_no_post() {
-  echo "readme" > README.md
-  git add README.md
-  GIT_COMMITTER_DATE="${TODAY}T12:00:00Z" GIT_AUTHOR_DATE="${TODAY}T12:00:00Z" git commit -q -m "readme"
-  run_find push
-}
-_push_mixed() {
-  make_post "content/posts/ok.md"     "$TODAY"
-  make_post "content/posts/draft.md"  "$TODAY" true
-  make_post "content/posts/future.md" "$TOMORROW"
-  git add content/posts/
-  GIT_COMMITTER_DATE="${TODAY}T12:00:00Z" GIT_AUTHOR_DATE="${TODAY}T12:00:00Z" git commit -q -m "mixed"
-  run_find push
-}
-_push_no_promote() {
-  make_post "content/posts/quiet.md" "$TODAY" false true
-  commit_at "content/posts/quiet.md" "$TODAY"
-  run_find push
-}
-
-result=$(with_repo _push_today)
-assert_eq   "push: promotes new post with today's publishDate" "content/posts/new.md" "$result"
-
-result=$(with_repo _push_future)
-assert_empty "push: skips new post with future publishDate" "$result"
-
-result=$(with_repo _push_draft)
-assert_empty "push: skips draft post" "$result"
-
-result=$(with_repo _push_no_post)
-assert_empty "push: no output when commit has no posts" "$result"
-
-result=$(with_repo _push_mixed)
-assert_eq   "push: promotes only the publishable post from a mixed commit" "content/posts/ok.md" "$result"
-
-result=$(with_repo _push_no_promote)
-assert_empty "push: skips post with promote: false" "$result"
-
 # ── schedule mode ─────────────────────────────────────────────────────────────
 
 echo ""
@@ -233,21 +188,12 @@ _sched_no_promote() {
   commit_at "content/posts/quiet.md" "$YESTERDAY"
   run_find schedule
 }
-_sched_dedup() {
-  # pushed-today: committed today (should be deduped, push trigger ran it)
-  make_post "content/posts/pushed-today.md" "$TODAY"
-  commit_at "content/posts/pushed-today.md" "$TODAY"
-  # scheduled: committed yesterday, publishDate today → should promote
-  make_post "content/posts/scheduled.md" "$TODAY"
-  commit_at "content/posts/scheduled.md" "$YESTERDAY"
-  run_find schedule
-}
 
 result=$(with_repo _sched_yesterday)
 assert_eq   "schedule: promotes post committed yesterday with today's publishDate" "content/posts/sched.md" "$result"
 
 result=$(with_repo _sched_today)
-assert_empty "schedule: dedup — skips post added today (push trigger already ran)" "$result"
+assert_eq   "schedule: promotes post added today with today's publishDate (no push dedup)" "content/posts/same.md" "$result"
 
 result=$(with_repo _sched_future)
 assert_empty "schedule: skips post with future publishDate" "$result"
@@ -257,9 +203,6 @@ assert_empty "schedule: skips draft even when publishDate matches today" "$resul
 
 result=$(with_repo _sched_no_promote)
 assert_empty "schedule: skips post with promote: false" "$result"
-
-result=$(with_repo _sched_dedup)
-assert_eq   "schedule: dedup skips today-added, promotes yesterday-committed" "content/posts/scheduled.md" "$result"
 
 _sched_no_pub_alone() {
   # Legacy post with no publishDate — schedule scan must not crash on it.
@@ -316,19 +259,19 @@ _edge_datetime_pub() {
   # publishDate with time component — get_publish_date must strip T...
   make_post_raw "content/posts/dt.md" "${TODAY}T12:00:00Z"
   commit_at "content/posts/dt.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 _edge_missing_pub_date() {
-  # No publishDate field — validate_post must SKIP
+  # No publishDate field — schedule must SKIP
   make_post_no_date "content/posts/nodate.md"
   commit_at "content/posts/nodate.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 _edge_quoted_date() {
   # publishDate: "YYYY-MM-DD" — tr -d '"' branch in get_publish_date
   make_post_raw "content/posts/quoted.md" "\"${TODAY}\""
   commit_at "content/posts/quoted.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 _edge_sched_empty_dir() {
   # content/posts/ has no .md files — schedule must be a no-op, not a glob failure
@@ -347,29 +290,29 @@ _edge_body_promote_false() {
   # "promote: false" appears in body content at column 0 — must NOT skip
   make_post_with_body_line "content/posts/bodypromote.md" "$TODAY" "promote: false"
   commit_at "content/posts/bodypromote.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 _edge_body_draft_true() {
   # "draft: true" appears in body content at column 0 — must NOT mark as draft
   make_post_with_body_line "content/posts/bodydraft.md" "$TODAY" "draft: true"
   commit_at "content/posts/bodydraft.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 _edge_body_publish_date() {
   # "publishDate: ..." appears in body content at column 0 — frontmatter value wins
   make_post_with_body_line "content/posts/bodypub.md" "$TODAY" "publishDate: 2099-01-01T00:00:00Z"
   commit_at "content/posts/bodypub.md" "$TODAY"
-  run_find push
+  run_find schedule
 }
 
 result=$(with_repo _edge_datetime_pub)
-assert_eq    "edge: push handles publishDate with time component (get_publish_date strips T...)" "content/posts/dt.md" "$result"
+assert_eq    "edge: schedule handles publishDate with time component (get_publish_date strips T...)" "content/posts/dt.md" "$result"
 
 result=$(with_repo _edge_missing_pub_date)
-assert_empty "edge: push skips post with missing publishDate" "$result"
+assert_empty "edge: schedule skips post with missing publishDate" "$result"
 
 result=$(with_repo _edge_quoted_date)
-assert_eq    "edge: push handles quoted publishDate (tr -d '\"' branch)" "content/posts/quoted.md" "$result"
+assert_eq    "edge: schedule handles quoted publishDate (tr -d '\"' branch)" "content/posts/quoted.md" "$result"
 
 result=$(with_repo _edge_sched_empty_dir)
 assert_empty "edge: schedule is a no-op when content/posts has no .md files" "$result"


### PR DESCRIPTION
Simplifies the social media promotion pipeline by removing the push-triggered promotion mode. Posts are now promoted only via the nightly cron (6 AM UTC) or manual dispatch, eliminating the need for deduplication logic between push and schedule triggers.

## Summary

The promotion workflow previously had three triggers: push (for newly added posts), nightly cron (for scheduled posts), and manual dispatch. This change removes the push trigger entirely, as `claude-code-action` does not support the `push` event type. Posts merged on their publish day after the 6 AM cron will need to be promoted manually via the workflow dispatch button.

## Key Changes

- **Removed push mode** from `scripts/find-promotable-posts.sh`: deleted the `push` case that filtered for newly added files via `git diff --diff-filter=A`
- **Removed deduplication logic**: deleted `file_added_date()` function and the check that skipped posts added today (which was meant to avoid double-promotion between push and cron triggers)
- **Updated schedule mode**: now scans all posts without the dedup check
- **Simplified workflow trigger configuration** (`.github/workflows/promote-post.yml`):
  - Removed `push` event trigger
  - Made `post_path` input optional for manual dispatch (blank = promote everything due today)
  - Updated conditional logic to handle manual dispatch with/without a specific post path
  - Removed `fetch-depth: 0` (no longer needed for git log dedup)
- **Updated documentation** (CLAUDE.md): clarified that there are now only two triggers (cron + manual), explained the limitation, and removed dedup explanation
- **Updated test suite** (`scripts/test-find-promotable-posts.sh`):
  - Removed all push mode test cases (`_push_today`, `_push_future`, `_push_draft`, etc.)
  - Removed dedup-specific test (`_sched_dedup`)
  - Updated schedule mode test to expect promotion of today-added posts (no longer skipped)
  - Migrated edge-case tests from push to schedule mode
- **Updated helper script** (`scripts/posts-publishing-today.sh`): removed mention of dedup logic in comments

## Implementation Details

The schedule mode now unconditionally promotes any post with `publishDate == today` that passes validation (not draft, `promote: false` honored). The workflow dispatch button can target a specific post (skipping date validation) or run in schedule mode to promote everything due today.

https://claude.ai/code/session_01SQQJ7r1gKC2SY2W1RQ9VDZ