### PR TITLE
layout: add newsletter form to end of blog posts

### DIFF
--- a/assets/css/extended/newsletter.css
+++ b/assets/css/extended/newsletter.css
@@ -264,3 +264,25 @@
 .newsletter-form--placeholder p {
   margin: 0;
 }
+
+/* End-of-post call-to-action wrapper (layouts/partials/extend_post_content.html).
+   Sits after the post body, before the tag/share footer. The quiet 2px
+   var(--tertiary) top rule mirrors the .home-divider / PaperMod md-content hr
+   treatment above, so it adapts to light and dark themes automatically. The
+   inner .newsletter-form keeps its own styling (max-width, responsive stack).
+*/
+.post-newsletter {
+  margin: 2.5rem 0 1rem;
+  padding-top: 1.5rem;
+  border-top: 2px solid var(--tertiary);
+}
+
+.post-newsletter__heading {
+  margin: 0 0 0.25rem;
+}
+
+.post-newsletter__blurb {
+  margin: 0 0 0.75rem;
+  color: var(--secondary);
+  font-size: 0.95em;
+}

--- a/layouts/partials/extend_post_content.html
+++ b/layouts/partials/extend_post_content.html
@@ -8,7 +8,7 @@
 {{- if and (eq .Section "posts") site.Params.newsletter.mainCampaignId }}
 <section class="post-newsletter" aria-labelledby="post-newsletter-heading">
   <h3 id="post-newsletter-heading" class="post-newsletter__heading">Enjoyed this post?</h3>
-  <p class="post-newsletter__blurb">Get new posts in your inbox. No spam, unsubscribe anytime.</p>
+  <p class="post-newsletter__blurb">Get new posts in your inbox.</p>
   {{ partial "newsletter-form.html" (dict) }}
 </section>
 {{- end }}

--- a/layouts/partials/extend_post_content.html
+++ b/layouts/partials/extend_post_content.html
@@ -1,0 +1,14 @@
+{{- /* Override of PaperMod's empty extend_post_content stub.
+       Renders an inline newsletter subscription form at the end of blog
+       posts (after the body, before the tag/share footer). Gated to the
+       posts section so talks, notes, and standalone pages stay clean.
+       Reuses the shared newsletter-form partial, which falls back to the
+       main feed campaign (site.Params.newsletter.mainCampaignId) when
+       called with an empty dict. */ -}}
+{{- if and (eq .Section "posts") site.Params.newsletter.mainCampaignId }}
+<section class="post-newsletter" aria-labelledby="post-newsletter-heading">
+  <h3 id="post-newsletter-heading" class="post-newsletter__heading">Enjoyed this post?</h3>
+  <p class="post-newsletter__blurb">Get new posts in your inbox. No spam, unsubscribe anytime.</p>
+  {{ partial "newsletter-form.html" (dict) }}
+</section>
+{{- end }}


### PR DESCRIPTION
Most readers arrive on a single post via social links and never see the
homepage, where the subscription form lived. Render the existing Hakanai
newsletter form (main feed campaign) at the end of each blog post via
PaperMod's extend_post_content hook, gated to the posts section so talks,
notes, and standalone pages stay clean.

https://claude.ai/code/session_014C8KFiVKE59TK6Gzs9fVV2