### PR TITLE
Add Substack syndication feed with absolutised URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ showToc: true                 # optional, for long technical posts
 tocOpen: false                # optional
 draft: true                   # for WIP content; use future publishDate for scheduled posts instead
 promote: false                # optional; skip social-media promotion (defaults to promotable when omitted)
+substack: false               # optional; exclude from the Substack syndication feed (included when omitted)
 ---
 ```
 
@@ -91,6 +92,7 @@ promote: false                # optional; skip social-media promotion (defaults 
 - Do not quote scalar YAML values (dates, booleans) — only quote strings that contain special characters
 - Use `draft: true` for WIP content; use a future `publishDate` (with `draft` omitted) for scheduled posts
 - Set `promote: false` to publish a post but opt it out of the social-media promotion pipeline (`scripts/find-promotable-posts.sh`)
+- Set `substack: false` to publish a post but exclude it from the Substack syndication feed (`/substack.xml`, see [docs/substack-syndication.md](docs/substack-syndication.md))
 
 ### Content Types
 
@@ -171,6 +173,7 @@ GitHub Actions workflows:
 - **Giscus:** Comments via GitHub Discussions on `kakkoyun/me`. Config in `config.yaml` under `params.giscus`.
 - **Plausible + Hakanai:** Dual analytics. Extend via `params.analytics` in `config.yaml`.
 - **Renovate:** Auto-updates Hugo version (in `.hugo-version` + `netlify.toml`), GitHub Actions, and PaperMod submodule.
+- **Substack:** Blog posts are syndicated to Substack via a dedicated, Substack-tuned RSS feed at `/substack.xml` (output format `substack` in `config.yaml`, template `layouts/index.substack.xml`). Hugo stays canonical; Substack is a one-directional mirror you feed via `Settings → Import`. The feed emits full-text `<content:encoded>` with absolutised image/link URLs and a top "Originally published at" backlink (Substack supports no canonical tag). Opt a post out with `substack: false`. Setup and post-import steps are in [docs/substack-syndication.md](docs/substack-syndication.md).
 
 ## Buffer CLI Integration
 

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,19 @@ outputFormats:
     mediaType: text/plain
     isPlainText: true
     notAlternative: true
+  # Substack-tuned syndication feed (served at /substack.xml). Full-text
+  # <content:encoded> with absolutised image/link URLs and a top "Originally
+  # published at" backlink. Point Substack's Settings -> Import at this feed.
+  # See docs/substack-syndication.md.
+  substack:
+    name: substack
+    baseName: substack
+    mediaType: application/rss+xml
+    isPlainText: false
+    isHTML: false
+    noUgly: true
+    rel: alternate
+    notAlternative: true
 
 outputs:
   home:
@@ -30,6 +43,7 @@ outputs:
     - RSS
     - JSON
     - llms
+    - substack
   page:
     - HTML
     - MARKDOWN

--- a/docs/substack-syndication.md
+++ b/docs/substack-syndication.md
@@ -1,0 +1,78 @@
+# Substack syndication
+
+Blog posts are syndicated to Substack as a mirror. **Hugo stays the canonical
+source of truth**; Substack is a one-directional, lossy copy. Never edit a post
+on Substack and expect it to flow back — the canonical text lives in
+`content/posts/`.
+
+The Hugo side is fully automated by a dedicated feed; the Substack side is
+manual because Substack has no public publishing API and its native importer is
+a one-time/manual operation.
+
+## What Hugo generates
+
+A Substack-tuned RSS feed is published at **`https://kakkoyun.me/substack.xml`**.
+
+- **Output format:** `substack` (defined in `config.yaml`, added to `outputs.home`).
+- **Template:** `layouts/index.substack.xml`.
+- **Scope:** blog posts only (`content/posts`). Drafts and future-dated posts are
+  excluded by the production build; opt a specific post out with `substack: false`
+  in its frontmatter (mirrors `promote: false`). The shared `hiddenInRss: true`
+  flag also excludes a post.
+- **No item limit:** the whole eligible archive is in the feed, so the first
+  import can backfill everything in one pass.
+
+It differs from the generic `/index.xml` feed in three ways, each compensating
+for a Substack importer limitation:
+
+1. **Absolute URLs.** Substack does not re-host root-relative images
+   (`/uploads/...`) or resolve relative internal links. The template absolutises
+   every `href`/`src`/`srcset` against `https://kakkoyun.me`.
+2. **Original-post backlink.** Each post body starts with an italic
+   "Originally published at kakkoyun.me" link to the canonical URL.
+3. **SEO attribution.** Substack supports **no** canonical tag (neither automatic
+   nor manual), so the backlink above is the only attribution mechanism. Modern
+   search engines are lenient about same-author duplicate content, so a body
+   backlink is sufficient.
+
+## One-time setup
+
+1. In Substack: **Settings → Import** (a.k.a. Import/Export → Import posts).
+2. Paste the feed URL: `https://kakkoyun.me/substack.xml`.
+3. If Substack offers an **import-as-draft** toggle, use it — it lets you eyeball
+   formatting before sending to subscribers. If it offers **ongoing import**,
+   enable it so new posts flow in automatically. (Both options are
+   importer-version dependent and not guaranteed; fall back to a periodic manual
+   re-run of the import if ongoing import isn't available.)
+4. The first run pulls the full archive. If Substack caps a single run, re-run
+   the import or use Substack's one-time URL-paste import for the remainder.
+
+## Post-import checklist (the lossy parts Substack owns)
+
+The importer mangles things the feed can't fix. After each import, before
+publishing/sending on Substack:
+
+- **Images:** confirm every image rendered. Substack's image import is
+  unreliable; re-upload any that 404 to Substack's media library.
+- **Shortcodes:** the rendered HTML for `{{< sidenote >}}` / `{{< tooltip >}}`
+  (an `<aside>` / `<span class>`) is stripped by Substack to plain text. Only one
+  post currently uses these; reformat by hand if needed.
+- **Footnotes:** not converted to Substack footnotes; clean up if present.
+- **Backlink:** confirm the "Originally published at" line survived at the top.
+
+## Re-import caution
+
+Treat import as **additive**. Re-importing the same post may create a duplicate
+rather than update the existing one (Substack's dedupe behaviour is
+undocumented). After a post is imported, manage any further edits directly in
+Substack — don't re-import it.
+
+## Verifying the feed locally
+
+```bash
+make production                       # or: hugo --gc --minify
+xmllint --noout public/substack.xml   # valid XML
+grep -c '<content:encoded>' public/substack.xml          # full bodies present
+grep -c 'kakkoyun.mehttps://' public/substack.xml        # must be 0 (no doubled domain)
+grep -oE 'src="/[^"]*' public/substack.xml | grep -v https  # must be empty (no relative src)
+```

--- a/layouts/index.substack.xml
+++ b/layouts/index.substack.xml
@@ -76,14 +76,28 @@
       <guid>{{ .Permalink }}</guid>
       <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
       {{- /* Absolutise root-relative URLs so Substack can fetch images and
-             internal links resolve. Go regexp has no lookbehind, so anchor
-             each match on an attribute/whitespace boundary to avoid
-             re-prefixing URLs that are already absolute. The third pass
-             catches additional /uploads/ entries inside srcset comma lists. */ -}}
+             internal links resolve. Go regexp (RE2) has no lookbehind, so each
+             pass anchors on the attribute name (or an srcset descriptor) to
+             stay scoped to URLs and skip body text. `/[^/"]` deliberately
+             excludes protocol-relative `//host` URLs (and bare `/`).
+
+             href / src / srcset each get their own pass so a tag bearing more
+             than one of them is fully covered (the render hook actually emits
+             <source srcset> and <img src> as separate tags, but raw HTML in a
+             post could combine them). Those passes catch the first URL token of
+             each attribute; the final sweep then absolutises the remaining
+             comma-separated candidates of a responsive srcset list. It anchors
+             on the preceding `NNNw`/`Nx` descriptor that Hugo's render-image
+             hook always emits, so it cannot touch a `, /path` sitting inside a
+             code block. The sweep is idempotent (absolutised URLs no longer
+             start with `/`); one pass suffices, the loop is belt-and-suspenders. */ -}}
       {{- $c := .Content }}
-      {{- $c = $c | replaceRE `(<a[^>]+href=")(/[^"]*)` (printf `${1}%s${2}` $base) }}
-      {{- $c = $c | replaceRE `(<(?:img|source)[^>]+(?:src|srcset)=")(/[^"]*)` (printf `${1}%s${2}` $base) }}
-      {{- $c = $c | replaceRE `([",\s])(/uploads/)` (printf `${1}%s${2}` $base) }}
+      {{- $c = $c | replaceRE `(<[^>]+\shref=")(/[^/"][^"]*)` (printf `${1}%s${2}` $base) }}
+      {{- $c = $c | replaceRE `(<[^>]+\ssrc=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
+      {{- $c = $c | replaceRE `(<[^>]+\ssrcset=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
+      {{- range seq 3 }}
+      {{- $c = $c | replaceRE `([0-9][wx],\s*)(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
+      {{- end }}
       {{- $orig := printf `<p><em>Originally published at <a href="%s">kakkoyun.me</a>.</em></p>` .Permalink }}
       {{- $body := printf "%s\n%s" $orig $c }}
       <content:encoded>{{ printf "<![CDATA[%s]]>" $body | safeHTML }}</content:encoded>

--- a/layouts/index.substack.xml
+++ b/layouts/index.substack.xml
@@ -1,0 +1,93 @@
+{{- /*
+  Substack syndication feed for kakkoyun.me (served at /substack.xml).
+
+  Hugo stays the canonical source of truth; Substack is a mirror you feed
+  via Settings -> Import. This feed is specialised for Substack's importer,
+  which differs from a generic RSS reader in three ways we compensate for:
+
+    1. It does NOT re-host relative image URLs, so we absolutise every
+       root-relative href/src/srcset against site.BaseURL.
+    2. It supports no canonical tag (neither auto nor manual), so we inject
+       an "Originally published at" backlink at the top of each body for
+       attribution and SEO.
+    3. It only reliably carries full bodies via <content:encoded>, which we
+       always emit.
+
+  Scope: blog posts only (content/posts). Drafts and future-dated posts are
+  excluded by the production build (buildDrafts: false, no --buildFuture);
+  per-post opt-out via `substack: false` and the shared `hiddenInRss` flag.
+  See docs/substack-syndication.md for the operator runbook.
+*/ -}}
+{{- $authorEmail := "" }}
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}{{ $authorEmail = . }}{{ end }}
+    {{- with .name }}{{ $authorName = . }}{{ end }}
+  {{- else }}
+    {{- $authorName = . }}
+  {{- end }}
+{{- end }}
+
+{{- $base := site.BaseURL | strings.TrimSuffix "/" }}
+{{- $pages := where site.RegularPages "Section" "posts" }}
+{{- $pages = where $pages "Params.substack" "!=" false }}
+{{- $pages = where $pages "Params.hiddenInRss" "!=" true }}
+{{- $pages = sort $pages "PublishDate" "desc" }}
+
+{{- $rfc822 := "Mon, 02 Jan 2006 15:04:05 -0700" -}}
+{{- $now := now.Format $rfc822 -}}
+{{- $lastBuildDate := $now -}}
+{{- $pubDate := $now -}}
+{{- with $pages -}}
+{{- $lastBuildDate = (index .ByLastmod.Reverse 0).Lastmod.Format $rfc822 -}}
+{{- $pubDate = (index .ByPublishDate.Reverse 0).PublishDate.Format $rfc822 -}}
+{{- end -}}
+
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>{{ site.Title }}</title>
+    <link>{{ $base }}/</link>
+    <description>Posts from {{ site.Title }}, syndicated to Substack.</description>
+    {{- with site.Params.images }}
+    <image>
+      <title>{{ site.Title }}</title>
+      <url>{{ index . 0 | absURL }}</url>
+      <link>{{ index . 0 | absURL }}</link>
+    </image>
+    {{- end }}
+    <generator>Hugo</generator>
+    <language>{{ site.Language.Locale }}</language>{{ with $authorEmail }}
+    <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with site.Copyright }}
+    <copyright>{{ . | markdownify | plainify | strings.TrimPrefix "© " }}</copyright>{{ end }}
+    <lastBuildDate>{{ $lastBuildDate | safeHTML }}</lastBuildDate>
+    <pubDate>{{ $pubDate | safeHTML }}</pubDate>
+    {{- with .OutputFormats.Get "substack" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
+      {{- /* Absolutise root-relative URLs so Substack can fetch images and
+             internal links resolve. Go regexp has no lookbehind, so anchor
+             each match on an attribute/whitespace boundary to avoid
+             re-prefixing URLs that are already absolute. The third pass
+             catches additional /uploads/ entries inside srcset comma lists. */ -}}
+      {{- $c := .Content }}
+      {{- $c = $c | replaceRE `(<a[^>]+href=")(/[^"]*)` (printf `${1}%s${2}` $base) }}
+      {{- $c = $c | replaceRE `(<(?:img|source)[^>]+(?:src|srcset)=")(/[^"]*)` (printf `${1}%s${2}` $base) }}
+      {{- $c = $c | replaceRE `([",\s])(/uploads/)` (printf `${1}%s${2}` $base) }}
+      {{- $orig := printf `<p><em>Originally published at <a href="%s">kakkoyun.me</a>.</em></p>` .Permalink }}
+      {{- $body := printf "%s\n%s" $orig $c }}
+      <content:encoded>{{ printf "<![CDATA[%s]]>" $body | safeHTML }}</content:encoded>
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

Adds a dedicated RSS feed optimized for Substack's importer, enabling one-directional syndication of blog posts from Hugo (canonical source) to Substack (mirror). The feed compensates for three Substack importer limitations: lack of relative URL re-hosting, no canonical tag support, and reliance on `<content:encoded>` for full bodies.

## Key Changes

- **New output format:** Added `substack` RSS format to `config.yaml` with appropriate media type and settings
- **New feed template:** `layouts/index.substack.xml` generates a Substack-tuned RSS feed at `/substack.xml` with:
  - Full post bodies in `<content:encoded>` CDATA sections
  - Absolutised root-relative URLs in `href`, `src`, and `srcset` attributes (compensates for Substack's lack of image re-hosting)
  - "Originally published at kakkoyun.me" backlink prepended to each post body (provides attribution and SEO since Substack supports no canonical tag)
  - Proper RFC 822 date formatting and channel metadata
- **Scope control:** Posts can be excluded via `substack: false` frontmatter flag or the existing `hiddenInRss: true` flag; drafts and future-dated posts are automatically excluded
- **Documentation:** Added `docs/substack-syndication.md` with:
  - Setup instructions for the one-time Substack import
  - Post-import checklist for lossy transformations Substack owns (images, shortcodes, footnotes)
  - Re-import caution and local verification commands
- **Frontmatter guidance:** Updated `CLAUDE.md` to document the new `substack: false` flag alongside existing `promote: false`

## Implementation Details

The template uses three regex passes to absolutise URLs:
1. Root-relative `href` attributes in anchor tags
2. Root-relative `src`/`srcset` attributes in img/source tags
3. Additional `/uploads/` entries inside srcset comma lists (catches edge cases)

The feed includes the entire eligible archive (no item limit) to support full backfill on first import. Hugo remains the canonical source; Substack is a one-directional, lossy copy managed via manual re-import cycles.

https://claude.ai/code/session_01S2pjqZdWLb4gex2qsFs7Lz