### PR TITLE
layout: improve Substack feed rendering and skip cross-posts

### DIFF
--- a/docs/substack-syndication.md
+++ b/docs/substack-syndication.md
@@ -19,10 +19,15 @@ A Substack-tuned RSS feed is published at **`https://kakkoyun.me/substack.xml`**
   excluded by the production build; opt a specific post out with `substack: false`
   in its frontmatter (mirrors `promote: false`). The shared `hiddenInRss: true`
   flag also excludes a post.
+- **Cross-posts of cross-posts are skipped automatically.** A post whose
+  `canonicalUrl` points to a third party (e.g. Polar Signals, Meltwater) is a
+  republished-with-permission copy, so syndicating it to Substack would mirror a
+  mirror. Such posts are dropped from the feed; a post with no `canonicalUrl`, or
+  one pointing back at this site, is kept.
 - **No item limit:** the whole eligible archive is in the feed, so the first
   import can backfill everything in one pass.
 
-It differs from the generic `/index.xml` feed in three ways, each compensating
+It differs from the generic `/index.xml` feed in several ways, each compensating
 for a Substack importer limitation:
 
 1. **Absolute URLs.** Substack does not re-host root-relative images
@@ -34,6 +39,16 @@ for a Substack importer limitation:
    nor manual), so the backlink above is the only attribution mechanism. Modern
    search engines are lenient about same-author duplicate content, so a body
    backlink is sufficient.
+4. **Flattened code blocks.** Hugo's chroma highlighter renders each code block
+   as a line-number `<table>` wrapped in hundreds of inline styles; Substack
+   strips the styles and turns the line-number column into garbage text. The
+   template rewrites those to a clean `<pre><code>` (real data tables are left
+   alone).
+5. **Inlined sidenotes/tooltips.** `{{< sidenote >}}` becomes a parenthetical and
+   `{{< tooltip >}}` becomes `term (definition)`, since Substack strips the
+   `<aside>`/class-scoped CSS that positions them.
+6. **Cover image in the body.** The frontmatter cover image is prepended
+   (absolutised) as the first image so Substack picks it up as the featured image.
 
 ## One-time setup
 
@@ -52,12 +67,13 @@ for a Substack importer limitation:
 The importer mangles things the feed can't fix. After each import, before
 publishing/sending on Substack:
 
-- **Images:** confirm every image rendered. Substack's image import is
-  unreliable; re-upload any that 404 to Substack's media library.
-- **Shortcodes:** the rendered HTML for `{{< sidenote >}}` / `{{< tooltip >}}`
-  (an `<aside>` / `<span class>`) is stripped by Substack to plain text. Only one
-  post currently uses these; reformat by hand if needed.
-- **Footnotes:** not converted to Substack footnotes; clean up if present.
+- **Images:** confirm every image rendered (including the prepended cover).
+  Substack's image import is unreliable; re-upload any that 404 to Substack's
+  media library.
+- **Code blocks:** the feed already flattens them to clean `<pre><code>`; just
+  confirm they imported as code blocks rather than plain paragraphs.
+- **Sidenotes/tooltips:** the feed inlines these (parenthetical / `term
+  (definition)`); skim the affected posts to check the parentheticals read well.
 - **Backlink:** confirm the "Originally published at" line survived at the top.
 
 ## Re-import caution

--- a/layouts/index.substack.xml
+++ b/layouts/index.substack.xml
@@ -33,7 +33,19 @@
 {{- $pages := where site.RegularPages "Section" "posts" }}
 {{- $pages = where $pages "Params.substack" "!=" false }}
 {{- $pages = where $pages "Params.hiddenInRss" "!=" true }}
-{{- $pages = sort $pages "PublishDate" "desc" }}
+{{- /* Skip cross-posts of cross-posts: posts whose canonical lives on a third
+       party (Polar Signals, Meltwater, …) are republished-with-permission
+       copies, so syndicating them to Substack would mirror a mirror. Keep a
+       post when it has no canonicalUrl, or its canonicalUrl points back at
+       this site. `substack: false` remains a manual override on top of this. */ -}}
+{{- $eligible := slice }}
+{{- range $pages }}
+  {{- $canon := .Params.canonicalUrl }}
+  {{- if not (and $canon (not (hasPrefix $canon $base))) }}
+    {{- $eligible = $eligible | append . }}
+  {{- end }}
+{{- end }}
+{{- $pages = sort $eligible "PublishDate" "desc" }}
 
 {{- $rfc822 := "Mon, 02 Jan 2006 15:04:05 -0700" -}}
 {{- $now := now.Format $rfc822 -}}
@@ -92,6 +104,18 @@
              code block. The sweep is idempotent (absolutised URLs no longer
              start with `/`); one pass suffices, the loop is belt-and-suspenders. */ -}}
       {{- $c := .Content }}
+      {{- /* Flatten Hugo/chroma syntax-highlighted code blocks. With lineNos
+             on, chroma renders each block as a line-number <table> wrapped in
+             ~hundreds of inline styles; Substack strips the styles and turns
+             the line-number column into garbage text prefixing every line.
+             Keep only the code column's <pre> (identified by its width:100%
+             <td>), drop the styling, and leave a clean <pre><code>. Genuine
+             markdown data tables carry no width:100% code column, so they are
+             untouched. The second pass handles any non-table chroma wrapper. */ -}}
+      {{- $c = $c | replaceRE "(?s)<div class=\"highlight\">.*?<td[^>]*width:100%[^>]*>\\s*(<pre[^>]*>.*?</pre>)\\s*</td>\\s*</tr>\\s*</table>\\s*</div>\\s*</div>" `${1}` }}
+      {{- $c = $c | replaceRE "(?s)<div class=\"highlight\">\\s*(<pre[^>]*>.*?</pre>)\\s*</div>" `${1}` }}
+      {{- $c = $c | replaceRE `<pre[^>]*>` `<pre>` }}
+      {{- $c = $c | replaceRE `<span style="[^"]*">` `<span>` }}
       {{- $c = $c | replaceRE `(<[^>]+\shref=")(/[^/"][^"]*)` (printf `${1}%s${2}` $base) }}
       {{- $c = $c | replaceRE `(<[^>]+\ssrc=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
       {{- $c = $c | replaceRE `(<[^>]+\ssrcset=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}

--- a/layouts/index.substack.xml
+++ b/layouts/index.substack.xml
@@ -116,6 +116,14 @@
       {{- $c = $c | replaceRE "(?s)<div class=\"highlight\">\\s*(<pre[^>]*>.*?</pre>)\\s*</div>" `${1}` }}
       {{- $c = $c | replaceRE `<pre[^>]*>` `<pre>` }}
       {{- $c = $c | replaceRE `<span style="[^"]*">` `<span>` }}
+      {{- /* Sidenotes and tooltips collapse to stray inline text on Substack,
+             which strips <aside> and the class-scoped CSS that positions them.
+             Fold them into the prose instead: drop the superscript ref marker,
+             turn each sidenote into a parenthetical, and render each tooltip as
+             "term (definition)". */ -}}
+      {{- $c = $c | replaceRE `(?s)<span class="sidenote-ref"[^>]*>.*?</span>` "" }}
+      {{- $c = $c | replaceRE `(?s)<aside class="sidenote[^>]*>.*?<span class="sidenote-content">(.*?)</span>.*?</aside>` ` (<em>${1}</em>)` }}
+      {{- $c = $c | replaceRE `(?s)<span class="tooltip"[^>]*>\s*<span class="tooltip-term"[^>]*>(.*?)</span>\s*<span role="tooltip"[^>]*>(.*?)</span>\s*</span>` `${1} (${2})` }}
       {{- $c = $c | replaceRE `(<[^>]+\shref=")(/[^/"][^"]*)` (printf `${1}%s${2}` $base) }}
       {{- $c = $c | replaceRE `(<[^>]+\ssrc=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
       {{- $c = $c | replaceRE `(<[^>]+\ssrcset=")(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
@@ -123,7 +131,19 @@
       {{- $c = $c | replaceRE `([0-9][wx],\s*)(/[^/"][^"\s,]*)` (printf `${1}%s${2}` $base) }}
       {{- end }}
       {{- $orig := printf `<p><em>Originally published at <a href="%s">kakkoyun.me</a>.</em></p>` .Permalink }}
-      {{- $body := printf "%s\n%s" $orig $c }}
+      {{- /* Hugo keeps the cover image in frontmatter, not the body, so Substack
+             imports would have no header image. Prepend it (absolutised) as the
+             first image so Substack picks it up as the featured image. */ -}}
+      {{- $cover := "" }}
+      {{- with .Params.cover }}
+        {{- $alt := .alt | default "" | replaceRE `"` "&quot;" }}
+        {{- with .image }}
+          {{- $src := . }}
+          {{- if hasPrefix $src "/" }}{{ $src = printf "%s%s" $base $src }}{{ end }}
+          {{- $cover = printf `<p><img src="%s" alt="%s"></p>` $src $alt }}
+        {{- end }}
+      {{- end }}
+      {{- $body := printf "%s\n%s\n%s" $orig $cover $c }}
       <content:encoded>{{ printf "<![CDATA[%s]]>" $body | safeHTML }}</content:encoded>
     </item>
     {{- end }}


### PR DESCRIPTION
Follow-up to #238. Improves how `/substack.xml` renders once imported into Substack, and stops re-syndicating posts that are already someone else's canonical content.

Built on the fact that Substack's importer strips inline styles, classes, and `<aside>`s, supports no canonical tag, and keeps the Hugo cover image out of the body. Each change below compensates for one of those.

## Changes

**Skip cross-posts of cross-posts.** Posts whose `canonicalUrl` points to a third party (Polar Signals, Meltwater) are republished-with-permission copies — syndicating them to Substack would mirror a mirror. They're now dropped from the feed automatically. A post with no `canonicalUrl`, or one pointing back at this site, is kept; `substack: false` remains a manual override. **Feed drops from 20 to 15 items.**

The 5 excluded:
- `fantastic-symbols-and-where-to-find-them` (+ `-part-2`) → Polar Signals
- `ice-and-fire` → Polar Signals
- `profiling-python-and-ruby-using-ebpf` → Polar Signals
- `making-drone-builds-10-times-faster` → Meltwater

(`profiling-python-with-ebpf-a-new-frontier…` is a *separate, original* post and stays in.)

**Flatten code blocks.** With `lineNos` on, chroma renders each code block as a line-number `<table>` wrapped in hundreds of inline styles; Substack strips the styles and turns the line-number column into garbage text prefixing every line. The feed now rewrites those to a clean `<pre><code>` — **1112 inline `style=` attributes removed** — with code text preserved byte-for-byte. Genuine markdown data tables (no `width:100%` code column) are left untouched.

**Inline sidenotes/tooltips.** `{{< sidenote >}}` → an inline `(parenthetical)` (25 converted); `{{< tooltip >}}` → `term (definition)`. The superscript ref marker is dropped. Previously these collapsed to stray text mid-paragraph.

**Cover image in body.** The frontmatter cover image is prepended (absolutised) as the first image so Substack picks it up as the featured/header image. Applied to 9 of the 15 eligible posts.

Plus `docs/substack-syndication.md` documents the skip rule and the new transforms, and trims the now-automated steps from the post-import checklist.

## Verification

- `hugo --gc --minify` → `public/substack.xml` valid XML, 15 items.
- Cross-post exclusion checked two ways: all 5 external-canonical slugs absent, **and** a re-check of every one of the 15 feed items confirms none carries an external `canonicalUrl`.
- Code: 1112 → 0 inline styles, 0 chroma line-number tables, code text byte-identical (verified per-post).
- Sidenotes/tooltips: 0 leftover `<aside>`/`tooltip` markup; 25 parentheticals emitted.
- Cover: prepended on the 9 posts that declare one.
- URL absolutisation regression: 0 relative `src`/`href`, 0 doubled domains.

Note: I can't validate Substack's *rendered* output directly (it 403s automated fetchers and drafts are private), so this is validated against the generated feed Substack consumes. Best confirmed by re-importing `https://kakkoyun.me/substack.xml` after this deploys.

https://claude.ai/code/session_01S2pjqZdWLb4gex2qsFs7Lz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2pjqZdWLb4gex2qsFs7Lz)_