### PR TITLE
chore(mcp): add plausible, fal, pexels, pixabay MCP servers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,12 @@
     "allow": [
       "Bash(buffer:*)",
       "Bash(buffer-cli:*)",
-      "Skill(buffer)"
+      "Skill(buffer)",
+      "mcp__plausible__*",
+      "mcp__fal__*",
+      "mcp__pexels__*",
+      "mcp__pixabay__*"
     ]
-  }
+  },
+  "enabledMcpjsonServers": ["meme", "giphy", "readwise", "plausible", "fal", "pexels", "pixabay"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,8 @@ styles/*
 !styles/config/
 !styles/config/**
 
-# Local MCP config (may contain credentials)
-.mcp.json
+# .mcp.json is committed: every server MUST use op:// references, never literal secrets.
+!.mcp.json
 
 # Things3 Task Migration
 .migration/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,53 @@
+{
+  "mcpServers": {
+    "meme": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "IMGFLIP_USERNAME=$(op read 'op://Private/ImgFlip/username' --account my.1password.com) IMGFLIP_PASSWORD=$(op read 'op://Private/ImgFlip/password' --account my.1password.com) npx -y meme-mcp"
+      ]
+    },
+    "giphy": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "GIPHY_API_KEY=$(op read 'op://Private/Giphy API Key/credential' --account my.1password.com) npx -y mcp-server-giphy"
+      ]
+    },
+    "readwise": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "ACCESS_TOKEN=$(op read 'op://Private/Readwise API Key/credential' --account my.1password.com) npx -y @readwise/readwise-mcp"
+      ]
+    },
+    "plausible": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "npx -y mcp-remote https://plausible-mcp.sentry.dev/mcp --header \"Authorization: Bearer $(op read 'op://Private/Plausible API Key/credential' --account my.1password.com)\""
+      ]
+    },
+    "fal": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "npx -y mcp-remote https://mcp.fal.ai/mcp --header \"Authorization: Bearer $(op read 'op://Private/Fal API Key/credential' --account my.1password.com)\""
+      ]
+    },
+    "pexels": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "PEXELS_API_KEY=$(op read 'op://Private/Pexels API Key/credential' --account my.1password.com) npx -y mcp-pexels"
+      ]
+    },
+    "pixabay": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "PIXABAY_API_KEY=$(op read 'op://Private/Pixabay API Key/credential' --account my.1password.com) npx -y pixabay-mcp@latest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds four repo-scoped MCP servers to `.mcp.json` and **commits the file into VCS** (previously gitignored at `.gitignore:56`).
- Every server uses 1Password `op://` references — no literal secret enters git. The `.gitignore` rule is replaced with a negation + a comment enforcing the `op://`-only discipline.
- `.claude/settings.json` (committed) gains `enabledMcpjsonServers` so a fresh checkout pre-approves all repo servers, plus `mcp__{plausible,fal,pexels,pixabay}__*` permission allow-rules.

### New servers

| Name | Transport | Package | Credential |
|---|---|---|---|
| `plausible` | HTTP→stdio bridge (`mcp-remote`) | Sentry-hosted `plausible-mcp.sentry.dev` | `op://Private/Plausible API Key/credential` |
| `fal` | HTTP→stdio bridge (`mcp-remote`) | Official `mcp.fal.ai` (model-agnostic via `run_model(endpoint_id)`) | `op://Private/Fal API Key/credential` |
| `pexels` | stdio | `npx -y mcp-pexels` | `op://Private/Pexels API Key/credential` |
| `pixabay` | stdio | `npx -y pixabay-mcp@latest` | `op://Private/Pixabay API Key/credential` |

### Image commit workflow

fal, Pexels, and Pixabay all return URLs (not files). Workflow:
1. Pick result from MCP tool response
2. `curl -L -o static/uploads/<slug>.<ext> "<url>"`
3. Reference as `/uploads/<slug>.<ext>` per existing Cover Image Conventions

Pexels License and Pixabay Content License both allow blog republishing with no attribution — safe to commit into this public repo.

## Pre-merge checklist

- [ ] Create 1Password items: `Plausible API Key`, `Fal API Key`, `Pexels API Key`, `Pixabay API Key` (all in Private vault, `credential` field)
- [ ] Verify each key resolves: `op read 'op://Private/Fal API Key/credential'`
- [ ] Restart Claude Code → `/mcp` → confirm all four servers show **connected**
- [ ] Smoke test: Plausible site list, fal `search_models`, Pexels photo search, Pixabay illustration search