### PR TITLE
layout: add series navigation box to posts

### DIFF
--- a/assets/css/extended/series-nav.css
+++ b/assets/css/extended/series-nav.css
@@ -1,0 +1,70 @@
+/* Series navigation box
+   Rendered by layouts/partials/series-nav.html on posts that belong to a
+   `series` taxonomy term. A quiet boxed card between the post header and
+   the body: "Part N of M" kicker, series title linking to the term page,
+   and an ordered list of parts with the current one highlighted and
+   unlinked. All colors use theme variables so light/dark mode adapt. */
+
+.series-nav {
+  margin: var(--content-gap) 0;
+  padding: 1rem 1.25rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.series-nav__kicker {
+  display: block;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--secondary);
+}
+
+.series-nav__series-title {
+  font-weight: 600;
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-color: var(--tertiary);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.3em;
+}
+
+.series-nav__series-title:hover,
+.series-nav__series-title:focus-visible {
+  text-decoration-color: var(--primary);
+}
+
+.series-nav__list {
+  margin: 0.75rem 0 0;
+  padding: 0 0 0 1.5rem;
+}
+
+.series-nav__item {
+  padding: 0.15rem 0;
+  color: var(--secondary);
+}
+
+/* Underline part links so they don't rely on colour alone (matches the
+   Recent Notes / Issues list treatment and Lighthouse's link-in-text-block
+   audit). */
+.series-nav__item a {
+  color: var(--secondary);
+  text-decoration: underline;
+  text-decoration-color: var(--tertiary);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.3em;
+  transition: color 0.15s ease;
+}
+
+.series-nav__item a:hover,
+.series-nav__item a:focus-visible {
+  color: var(--primary);
+  text-decoration-color: var(--primary);
+}
+
+/* The post being read: highlighted, plain text, no self-link. */
+.series-nav__item--current {
+  color: var(--primary);
+  font-weight: 600;
+}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,10 @@
-{{- /* Override of PaperMod's single.html. The ONLY change from upstream is the
-       position of the `.post-tags` block: it is moved out of the footer to sit
-       directly under the article body, above the newsletter form rendered by
-       extend_post_content.html. Keep in sync with the theme on PaperMod bumps. */ -}}
+{{- /* Override of PaperMod's single.html. Changes from upstream:
+       1. The `.post-tags` block is moved out of the footer to sit directly
+          under the article body, above the newsletter form rendered by
+          extend_post_content.html.
+       2. The series-nav partial is rendered after the cover, before the
+          ToC/content, for posts that belong to a `series` taxonomy term.
+       Keep in sync with the theme on PaperMod bumps. */ -}}
 {{- define "main" }}
 
 <article class="post-single">
@@ -34,6 +37,7 @@
   </header>
   {{- $isHidden := (.Param "cover.hiddenInSingle") | default (.Param "cover.hidden") | default false }}
   {{- partial "cover.html" (dict "cxt" . "IsSingle" true "isHidden" $isHidden) }}
+  {{- partial "series-nav.html" . }}
   {{- if (.Param "ShowToc") }}
   {{- partial "toc.html" . }}
   {{- end }}

--- a/layouts/partials/series-nav.html
+++ b/layouts/partials/series-nav.html
@@ -1,0 +1,36 @@
+{{- /* Series navigation box.
+       Rendered on posts that carry the `series` taxonomy (config.yaml).
+       Lists every part of the series in chronological order (`date`
+       ascending — parts can share a `publishDate`, see the Fantastic
+       Symbols pair), labels the box "Part N of M", links the series
+       title to its taxonomy term page, and renders the current post as
+       plain highlighted text instead of a self-link. Hidden while a
+       series has only one published part. Styles live in
+       assets/css/extended/series-nav.css. */ -}}
+{{- $page := . }}
+{{- range $page.GetTerms "series" }}
+{{- $series := . }}
+{{- $parts := $series.Pages.ByDate }}
+{{- $total := len $parts }}
+{{- if gt $total 1 }}
+{{- $current := 0 }}
+{{- range $i, $part := $parts }}
+{{- if $part.Eq $page }}{{ $current = add $i 1 }}{{ end }}
+{{- end }}
+<nav class="series-nav" aria-label="Series: {{ $series.LinkTitle }}">
+  <div class="series-nav__header">
+    <span class="series-nav__kicker">Part {{ $current }} of {{ $total }} in the series</span>
+    <a class="series-nav__series-title" href="{{ $series.RelPermalink }}">{{ $series.LinkTitle }}</a>
+  </div>
+  <ol class="series-nav__list">
+    {{- range $parts }}
+    {{- if .Eq $page }}
+    <li class="series-nav__item series-nav__item--current" aria-current="page">{{ .Title }}</li>
+    {{- else }}
+    <li class="series-nav__item"><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{- end }}
+    {{- end }}
+  </ol>
+</nav>
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## What

Adds a series-navigation box to blog posts that belong to a `series` taxonomy term (multi-part posts). On any such post, a boxed `<nav>` renders between the cover and the ToC/content with:

- a "Part N of M in the series" kicker,
- the series title, linking to the taxonomy term page (`/series/<slug>/`),
- an ordered list of every part in the series, sorted by `date` ascending (both Fantastic Symbols parts share the same `publishDate`, so `date` is the sort key), with the current post highlighted and **unlinked** (plain text, `aria-current="page"`).

The box is hidden while a series has only one published part (no "Part 1 of 1" noise for series-in-progress like "How I Use Claude Code"). CSS only, no JS; all colors use PaperMod theme variables so light/dark mode adapt, and part links get the underline treatment used elsewhere (Lighthouse link-in-text-block audit).

### Files

- `layouts/partials/series-nav.html` — new partial (uses `.GetTerms "series"` — `series` is already a taxonomy in `config.yaml` — and the term page's `.Pages.ByDate`)
- `layouts/_default/single.html` — partial call added after the cover, before ToC/content
- `assets/css/extended/series-nav.css` — new styles

## Caveat: single.html override

`layouts/_default/single.html` was already an override shadowing PaperMod's `_default/single.html` (for the relocated `.post-tags` block); this PR adds a second delta (the `series-nav` partial call) and updates the header comment documenting both. On major PaperMod bumps this file needs re-syncing against the upstream template.

## Verification

Built with the pinned Hugo (v0.163.3, `hugo --gc --minify`) and grepped the rendered output:

- `public/posts/fantastic-symbols-and-where-to-find-them/index.html` — box present, "Part 1 of 2", Part 1 as plain highlighted text, Part 2 linked
- `public/posts/fantastic-symbols-and-where-to-find-them-part-2/index.html` — "Part 2 of 2", Part 1 linked, Part 2 unlinked (correct order despite shared `publishDate`)
- `public/posts/mentorship-in-open-source{,-part-2-mentee-playbook,-part-3-stewardship}/index.html` — all three show 3 entries in order ("Part 1 of 3" / "2 of 3" / "3 of 3"), current item unlinked in each
- `public/posts/ice-and-fire/index.html` — no series box (non-series post)
- `series-nav__*` rules present in the bundled `public/assets/css/stylesheet.*.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcRmqhn1kinHXHj6LZrhQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcRmqhn1kinHXHj6LZrhQ2)_