### PR TITLE
layout: fill structured-data gaps (site-default social/schema image)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -121,6 +121,11 @@ params:
   author:
     name: "Kemal Akkoyun"
     email: "kakkoyun@gmail.com"
+  # Site-default social/schema image. PaperMod's get-page-images falls back to
+  # this when a page has no cover image, filling og:image, twitter:image, and
+  # the BlogPosting "image" field on cover-less pages.
+  images:
+    - "/img/android-chrome-512x512.png"
   schema:
     publisherType: "Person"
   keywords:


### PR DESCRIPTION
## Structured-data audit

Inspected the rendered production build (`hugo --gc --minify`, Hugo v0.163.3) for a post page (`/posts/ice-and-fire/`), the homepage, `/start-here/`, and list/taxonomy pages.

### What PaperMod already emits (no changes needed)

- **BlogPosting JSON-LD** on every single page: `headline`, `description`, `keywords`, `articleBody`, `wordCount`, `datePublished`, `dateModified`, `author` (Person), `mainEntityOfPage`, `publisher` (Person, via the existing `schema.publisherType: "Person"` param), and `image` when the page has a cover
- **BreadcrumbList JSON-LD** on posts and section pages (emitted regardless of the `showBreadCrumbs` UI param)
- **Person JSON-LD** on the homepage with `sameAs` populated from `socialIcons`
- **OpenGraph** (`og:type article`, `article:published_time`/`modified_time`/`section`/`tag`), **Twitter cards**, and **canonical** links

### The one genuine gap

Pages **without a cover image** — homepage, `/start-here/`, list pages, and several posts (`goproxy-fallback-behind-vpn`, `hustle-culture-startup-lessons`, the `fantastic-symbols` series, …) — shipped **no `og:image`, no `twitter:image` (card degraded to bare `summary`), and no `image` in BlogPosting**.

### The fix (config-only, 5 lines)

PaperMod's `_funcs/get-page-images` helper already falls back to site-level `params.images` when a page has neither a cover nor bundle images, and all three templates (opengraph, twitter_cards, schema_json) route through it. So no template code was added — just set the param in `config.yaml` to an existing file: `/img/android-chrome-512x512.png` (the 512×512 site icon already under `static/img/`). `layouts/partials/extend_head.html` is untouched.

### Validation

- `hugo --gc --minify` passes; `bash scripts/verify-build.sh` → all smoke checks pass
- Cover-less pages now emit `og:image`, `twitter:image` + `twitter:card summary_large_image`, and BlogPosting `image` = `https://kakkoyun.me/img/android-chrome-512x512.png`
- Pages with their own cover (e.g. `/posts/ice-and-fire/`) are byte-identical in behavior — cover still wins
- Every `ld+json` block on the checked pages parses as valid JSON; no duplicate schema types on any page
- The referenced image is present in the build output (`public/img/android-chrome-512x512.png`)

### Noted but intentionally not changed

- Taxonomy *term* pages (e.g. `/categories/engineering/`) get no JSON-LD from PaperMod (it only covers `IsPage`/`IsSection`); fixing that would need custom template code for marginal SEO value
- Homepage Person schema uses the favicon as `image` — a PaperMod default, acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcRmqhn1kinHXHj6LZrhQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcRmqhn1kinHXHj6LZrhQ2)_