### PR TITLE
layout: de-card list entries and group section lists by year

### DIFF
--- a/assets/css/extended/list-polish.css
+++ b/assets/css/extended/list-polish.css
@@ -1,0 +1,46 @@
+/* De-carded list entries + year headings for section archives (TIL-inspired).
+   Year headings are emitted by layouts/_default/list.html for section lists
+   only (posts/talks); home and term pages keep the flat, unheaded layout.
+
+   PaperMod's card look lives in themes/PaperMod/assets/css/common/post-entry.css:
+     .post-entry { background: var(--entry); border: 1px solid var(--border);
+                   border-radius: var(--radius); padding: var(--gap); ... }
+     .post-entry:hover, .post-entry:focus-within {
+       transform: translateY(-2px); border-color: var(--tertiary); }
+   We override only the box-look properties (background/border/border-radius/
+   padding/margin) to flatten the entry. `position: relative` is left
+   untouched -- .entry-link's full-cover overlay anchor depends on the entry
+   being its positioning context. The theme's hover/focus-within rule also
+   recolors the border to --tertiary, which would redraw a card outline on
+   hover even with a transparent background, so that one property
+   (border-color) is neutralized here too; the translateY lift is left as-is
+   since it isn't part of the boxed-card look. */
+
+.post-entry,
+.first-entry {
+  background: transparent;
+  box-shadow: none;
+  border: 1px solid transparent;
+  border-radius: 0;
+  padding: 12px 0;
+  margin-bottom: 8px;
+}
+
+.post-entry:hover,
+.post-entry:focus-within {
+  background: var(--code-bg);
+  border-color: transparent;
+  border-radius: var(--radius);
+}
+
+.post-entry .entry-header h2 {
+  font-size: 22px;
+}
+
+.archive-year {
+  margin: 28px 0 4px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--secondary);
+  font-size: 1.1rem;
+}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,16 @@
 {{- $pages = slice }}
 {{- end }}
 
-{{- $paginator := .Paginate $pages }}
+{{- /* Sections get year-grouped archives (mirrors list.md's GroupByDate "2006").
+       .Paginate may run only ONCE per context, and GroupByDate cannot run on the
+       bare `slice` that hideAutoList assigns (newsletter/_index.md), hence the guard. */ -}}
+{{- $grouped := and (eq .Kind "section") (not (.Param "hideAutoList")) }}
+{{- $paginator := "" }}
+{{- if $grouped }}
+{{- $paginator = .Paginate ($pages.GroupByDate "2006") }}
+{{- else }}
+{{- $paginator = .Paginate $pages }}
+{{- end }}
 
 {{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
 {{- partial "home_info.html" . }}
@@ -114,6 +123,41 @@
 {{- end }}
 {{- end }}
 
+{{- if $grouped }}
+{{- range $paginator.PageGroups }}
+<h2 class="archive-year">{{ .Key }}</h2>
+{{- range .Pages }}
+<article class="post-entry">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">
+      {{- .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h2>
+  </header>
+  {{- if (ne (.Param "hideSummary") true) }}
+  <div class="entry-content">
+    <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+{{- end }}
+{{- else }}
 {{- $term := .Data.Term }}
 {{- range $index, $page := $paginator.Pages }}
 
@@ -155,6 +199,7 @@
   {{- end }}
   <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
 </article>
+{{- end }}
 {{- end }}
 
 {{- if not .IsHome }}


### PR DESCRIPTION
## Summary

Part of the TIL-theme feature port — the "minimalist UI" light-polish slice. Two visual changes, nothing structural:

1. **De-carded list entries** (CSS only): `.post-entry` boxes lose background/shadow/border everywhere, gaining a quiet hover tint instead. PaperMod's hover border-recolor is explicitly neutralized so no card outline reappears on hover/focus.
2. **Year-grouped section lists**: `/posts/` and `/talks/` now render TIL-style `<h2 class="archive-year">` headings via `GroupByDate "2006"`. Home and taxonomy/term pages stay flat — verified DOM-byte-identical to master.

Deliberately out of scope (per plan): fonts, palette, content width (the sidenote margin-note CSS depends on the current measure).

## Files

- `layouts/_default/list.html` — paginator becomes a guarded conditional (year-grouping only for `.Kind == "section"` without `hideAutoList`; single `.Paginate` call preserved — the newsletter section's `hideAutoList: true` bare-slice path would otherwise hard-fail the build); existing flat loop kept character-identical for home/terms
- `assets/css/extended/list-polish.css` — de-carding + `.archive-year` styling, PaperMod variables only, dark mode inherits

## Verification

- 11/11 acceptance checks (implementer) + full independent QA re-run in a fresh worktree: GREEN, no fixes needed
- Byte-diffs vs master build: homepage and `/categories/talks/` identical (asset fingerprints aside); `newsletter/index.html`, `about/`, and the `/posts/index.md` markdown alternate also spot-verified identical
- Year-group integrity: every entry's date matches its heading year; years strictly descending; pagination footer intact on `/posts/page/2/`
- `make production && make verify` green; no new build warnings

## Review notes

- Netlify preview: eyeball `/posts/` and `/talks/` (year headings, de-carded rows, hover tint) in light + dark.
- A year heading repeats across a pagination boundary when a year spans pages (2026 on posts p.1 and p.2) — known behavior, matches how the paginator chunks groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV)_