### PR TITLE
layout: add automatic link index and connected-pages sections

### DIFF
--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -17,6 +17,7 @@ body.dark {
   --graph-label: #aaa;
 }
 .graph-canvas-wrap {
+  position: relative;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--entry);
@@ -24,6 +25,21 @@ body.dark {
   overflow: hidden;
 }
 .graph-canvas-wrap canvas { display: block; width: 100%; }
+.graph-controls {
+  position: absolute; top: 8px; right: 8px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.graph-controls button {
+  width: 28px; height: 28px; padding: 0;
+  background: var(--entry);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--secondary);
+  font: inherit; line-height: 1;
+  cursor: pointer;
+}
+.graph-controls button:hover,
+.graph-controls button:focus-visible { color: var(--primary); }
 .graph-legend { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0.5rem 0 1rem; font-size: 0.85rem; color: var(--secondary); }
 .graph-legend__item::before {
   content: ""; display: inline-block; width: 10px; height: 10px;

--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -29,6 +29,7 @@ body.dark {
   content: ""; display: inline-block; width: 10px; height: 10px;
   border-radius: 50%; margin-right: 6px; vertical-align: baseline;
 }
+.graph-alt-nav { margin: 0.5rem 0 0; font-size: 0.85rem; color: var(--secondary); }
 .graph-legend__item--posts::before      { background: var(--graph-node-posts); }
 .graph-legend__item--talks::before      { background: var(--graph-node-talks); }
 .graph-legend__item--newsletter::before { background: var(--graph-node-newsletter); }

--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -1,0 +1,35 @@
+/* Content-graph page (/graph/): canvas container, legend, node palette.
+   Colors are single-sourced here; graph.js reads them via getComputedStyle. */
+:root {
+  --graph-node-posts: #2e7dd1;
+  --graph-node-talks: #8256d0;
+  --graph-node-newsletter: #347d39;
+  --graph-node-pages: #966600;
+  --graph-edge: rgba(128, 128, 128, 0.35);
+  --graph-label: #555;
+}
+body.dark {
+  --graph-node-posts: #539bf5;
+  --graph-node-talks: #986ee2;
+  --graph-node-newsletter: #57ab5a;
+  --graph-node-pages: #c69026;
+  --graph-edge: rgba(200, 200, 200, 0.25);
+  --graph-label: #aaa;
+}
+.graph-canvas-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--entry);
+  touch-action: none;
+  overflow: hidden;
+}
+.graph-canvas-wrap canvas { display: block; width: 100%; }
+.graph-legend { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0.5rem 0 1rem; font-size: 0.85rem; color: var(--secondary); }
+.graph-legend__item::before {
+  content: ""; display: inline-block; width: 10px; height: 10px;
+  border-radius: 50%; margin-right: 6px; vertical-align: baseline;
+}
+.graph-legend__item--posts::before      { background: var(--graph-node-posts); }
+.graph-legend__item--talks::before      { background: var(--graph-node-talks); }
+.graph-legend__item--newsletter::before { background: var(--graph-node-newsletter); }
+.graph-legend__item--pages::before      { background: var(--graph-node-pages); }

--- a/assets/css/extended/page-links.css
+++ b/assets/css/extended/page-links.css
@@ -1,0 +1,58 @@
+/* Connected-pages nav ("Links to" / "Linked from")
+   Rendered by layouts/partials/page-links.html after the tags block on single
+   pages of posts/talks/newsletter, from the site-wide link index built by the
+   render-link.html hook. Two groups side by side on wide viewports, stacked
+   below. All colors use theme variables so light/dark mode adapt. */
+
+.page-links {
+  margin: var(--content-gap) 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+@media (min-width: 768px) {
+  .page-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+  }
+
+  .page-links__group {
+    flex: 1 1 240px;
+  }
+}
+
+.page-links__heading {
+  display: block;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--secondary);
+  margin: 0 0 0.5rem;
+}
+
+.page-links__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.page-links__list li {
+  padding: 0.25rem 0;
+  font-size: 0.95rem;
+}
+
+.page-links__list a {
+  color: var(--secondary);
+  text-decoration: underline;
+  text-decoration-color: var(--tertiary);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.3em;
+  transition: color 0.15s ease;
+}
+
+.page-links__list a:hover,
+.page-links__list a:focus-visible {
+  color: var(--primary);
+  text-decoration-color: var(--primary);
+}

--- a/assets/css/extended/page-links.css
+++ b/assets/css/extended/page-links.css
@@ -1,8 +1,9 @@
 /* Connected-pages nav ("Links to" / "Linked from")
    Rendered by layouts/partials/page-links.html after the tags block on single
-   pages of posts/talks/newsletter, from the site-wide link index built by the
-   render-link.html hook. Two groups side by side on wide viewports, stacked
-   below. All colors use theme variables so light/dark mode adapt. */
+   pages of posts/talks/newsletter, fed by the RawContent-scanning link index
+   in layouts/partials/functions/link-index.html. Two groups side by side on
+   wide viewports, stacked below. All colors use theme variables so light/dark
+   mode adapt. */
 
 .page-links {
   margin: var(--content-gap) 0 0;

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -1,0 +1,189 @@
+(function () {
+  "use strict";
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var canvas = document.getElementById("site-graph");
+    if (!canvas) return;
+    fetch(canvas.dataset.graphSrc)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { init(canvas, data); })
+      .catch(function (err) { console.warn("graph: failed to load data", err); });
+  });
+
+  function readColors() {
+    var cs = getComputedStyle(document.body);
+    function v(name, fb) { return cs.getPropertyValue(name).trim() || fb; }
+    return {
+      posts: v("--graph-node-posts", "#2e7dd1"), talks: v("--graph-node-talks", "#8256d0"),
+      newsletter: v("--graph-node-newsletter", "#347d39"), pages: v("--graph-node-pages", "#966600"),
+      edge: v("--graph-edge", "rgba(128,128,128,0.35)"), label: v("--graph-label", "#555")
+    };
+  }
+
+  function init(canvas, data) {
+    var ctx = canvas.getContext("2d"), wrap = canvas.parentElement;
+    var reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var colors = readColors(), width = 0, height = 0;
+    var nodesById = {};
+    var nodes = Object.keys(data.pages).map(function (id) {
+      var p = data.pages[id];
+      var n = { id: id, title: p.title, section: p.section, x: 0, y: 0, vx: 0, vy: 0, degree: 0 };
+      nodesById[id] = n;
+      return n;
+    });
+    var seen = {}, links = [];
+    Object.keys(data.graph).forEach(function (id) {
+      var src = nodesById[id];
+      if (!src) return;
+      (data.graph[id].out || []).forEach(function (target) {
+        var tgt = nodesById[target];
+        if (!tgt) return;
+        var key = id < target ? id + "|" + target : target + "|" + id;
+        if (seen[key]) return;
+        seen[key] = true;
+        links.push({ source: src, target: tgt });
+      });
+    });
+    links.forEach(function (l) { l.source.degree++; l.target.degree++; });
+    function radius(n) { return Math.min(3 + 1.5 * Math.sqrt(n.degree), 12); }
+
+    function resize() {
+      width = wrap.getBoundingClientRect().width;
+      height = Math.min(window.innerHeight * 0.7, 600);
+      var dpr = window.devicePixelRatio || 1;
+      canvas.width = width * dpr; canvas.height = height * dpr; canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    function place() {
+      var cx = width / 2, cy = height / 2, maxR = 0.4 * Math.min(width, height);
+      nodes.forEach(function (n) {
+        var ang = Math.random() * Math.PI * 2, rad = Math.random() * maxR;
+        n.x = cx + Math.cos(ang) * rad; n.y = cy + Math.sin(ang) * rad;
+      });
+    }
+    resize(); place();
+    var alpha = 1, hovered = null, dragged = null, rafId = null;
+
+    function tick() {
+      var cx = width / 2, cy = height / 2, i, j;
+      for (i = 0; i < nodes.length; i++) {
+        for (j = i + 1; j < nodes.length; j++) {
+          var a = nodes[i], b = nodes[j], dx = b.x - a.x, dy = b.y - a.y;
+          var d2 = dx * dx + dy * dy || 0.01, d = Math.sqrt(d2), f = (800 / d2) * alpha;
+          var fx = (dx / d) * f, fy = (dy / d) * f;
+          a.vx -= fx; a.vy -= fy; b.vx += fx; b.vy += fy;
+        }
+      }
+      links.forEach(function (l) {
+        var dx = l.target.x - l.source.x, dy = l.target.y - l.source.y;
+        var d = Math.sqrt(dx * dx + dy * dy) || 0.01, f = (d - 80) * 0.04 * alpha;
+        var fx = (dx / d) * f, fy = (dy / d) * f;
+        l.source.vx += fx; l.source.vy += fy; l.target.vx -= fx; l.target.vy -= fy;
+      });
+      nodes.forEach(function (n) {
+        if (n === dragged) return;
+        n.vx += (cx - n.x) * 0.02 * alpha; n.vy += (cy - n.y) * 0.02 * alpha;
+        n.vx *= 0.85; n.vy *= 0.85;
+        n.x += n.vx; n.y += n.vy;
+        n.x = Math.max(10, Math.min(width - 10, n.x));
+        n.y = Math.max(10, Math.min(height - 10, n.y));
+      });
+      alpha *= 0.98;
+    }
+
+    function neighborsOf(n) {
+      var set = {};
+      links.forEach(function (l) {
+        if (l.source === n) set[l.target.id] = true;
+        else if (l.target === n) set[l.source.id] = true;
+      });
+      return set;
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, width, height);
+      var neigh = hovered ? neighborsOf(hovered) : null;
+      ctx.strokeStyle = colors.edge; ctx.lineWidth = 1;
+      links.forEach(function (l) {
+        ctx.globalAlpha = hovered && l.source !== hovered && l.target !== hovered ? 0.25 : 1;
+        ctx.beginPath(); ctx.moveTo(l.source.x, l.source.y); ctx.lineTo(l.target.x, l.target.y); ctx.stroke();
+      });
+      nodes.forEach(function (n) {
+        var isNeighbor = n === hovered || (neigh && neigh[n.id]);
+        ctx.globalAlpha = hovered && !isNeighbor ? 0.25 : 1;
+        ctx.fillStyle = colors[n.section] || colors.pages;
+        ctx.beginPath(); ctx.arc(n.x, n.y, radius(n), 0, Math.PI * 2); ctx.fill();
+      });
+      ctx.globalAlpha = 1; ctx.font = "11px system-ui, sans-serif";
+      ctx.fillStyle = colors.label; ctx.textBaseline = "middle";
+      nodes.forEach(function (n) {
+        var isNeighbor = n === hovered || (neigh && neigh[n.id]);
+        var show = hovered ? isNeighbor : n.degree >= 3;
+        if (show) ctx.fillText(n.title, n.x + radius(n) + 3, n.y);
+      });
+    }
+
+    function loop() {
+      tick(); draw();
+      rafId = alpha < 0.005 ? null : requestAnimationFrame(loop);
+    }
+    if (reduced) {
+      for (var t = 0; t < 300 && alpha >= 0.005; t++) tick();
+      draw();
+    } else {
+      rafId = requestAnimationFrame(loop);
+    }
+
+    function pointerPos(e) {
+      var rect = canvas.getBoundingClientRect();
+      return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+    function hitTest(x, y) {
+      var best = null, bestD = Infinity;
+      nodes.forEach(function (n) {
+        var dx = x - n.x, dy = y - n.y, d2 = dx * dx + dy * dy, r = radius(n) + 6;
+        if (d2 <= r * r && d2 < bestD) { bestD = d2; best = n; }
+      });
+      return best;
+    }
+
+    canvas.addEventListener("mousemove", function (e) {
+      if (dragged) return;
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
+    });
+    canvas.addEventListener("click", function (e) {
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (hit) window.location.href = hit.id;
+    });
+    canvas.addEventListener("pointerdown", function (e) {
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (!hit) return;
+      dragged = hit;
+      canvas.setPointerCapture(e.pointerId);
+    });
+    canvas.addEventListener("pointermove", function (e) {
+      if (!dragged) return;
+      var p = pointerPos(e);
+      dragged.x = p.x; dragged.y = p.y; dragged.vx = 0; dragged.vy = 0;
+      draw();
+    });
+    function endDrag() {
+      if (!dragged) return;
+      dragged = null;
+      if (reduced) return;
+      alpha = Math.max(alpha, 0.3);
+      if (!rafId) rafId = requestAnimationFrame(loop);
+    }
+    canvas.addEventListener("pointerup", endDrag);
+    canvas.addEventListener("pointercancel", endDrag);
+
+    var resizeTimer = null;
+    window.addEventListener("resize", function () {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(function () { resize(); draw(); }, 150);
+    });
+    new MutationObserver(function () { colors = readColors(); draw(); })
+      .observe(document.body, { attributeFilter: ["class"] });
+  }
+})();

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -63,6 +63,7 @@
     }
     resize(); place();
     var alpha = 1, hovered = null, dragged = null, rafId = null;
+    var prevX = 0, prevY = 0, travel = Infinity;
 
     function tick() {
       var cx = width / 2, cy = height / 2, i, j;
@@ -133,6 +134,11 @@
     } else {
       rafId = requestAnimationFrame(loop);
     }
+    function reheat() {
+      if (reduced) return;
+      alpha = Math.max(alpha, 0.3);
+      if (!rafId) rafId = requestAnimationFrame(loop);
+    }
 
     function pointerPos(e) {
       var rect = canvas.getBoundingClientRect();
@@ -152,36 +158,49 @@
       var p = pointerPos(e), hit = hitTest(p.x, p.y);
       if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
     });
-    canvas.addEventListener("click", function (e) {
-      var p = pointerPos(e), hit = hitTest(p.x, p.y);
-      if (hit) window.location.href = hit.id;
-    });
     canvas.addEventListener("pointerdown", function (e) {
-      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      var p = pointerPos(e);
+      prevX = p.x; prevY = p.y; travel = 0;
+      var hit = hitTest(p.x, p.y);
       if (!hit) return;
       dragged = hit;
       canvas.setPointerCapture(e.pointerId);
     });
     canvas.addEventListener("pointermove", function (e) {
-      if (!dragged) return;
       var p = pointerPos(e);
+      travel += Math.hypot(p.x - prevX, p.y - prevY);
+      prevX = p.x; prevY = p.y;
+      if (!dragged) return;
       dragged.x = p.x; dragged.y = p.y; dragged.vx = 0; dragged.vy = 0;
       draw();
     });
-    function endDrag() {
+    canvas.addEventListener("pointerup", function (e) {
+      var wasDrag = dragged !== null;
+      dragged = null;
+      if (travel < 5) {
+        var p = pointerPos(e), hit = hitTest(p.x, p.y);
+        if (hit) { window.location.href = hit.id; return; }
+      }
+      if (wasDrag) reheat();
+    });
+    canvas.addEventListener("pointercancel", function () {
       if (!dragged) return;
       dragged = null;
-      if (reduced) return;
-      alpha = Math.max(alpha, 0.3);
-      if (!rafId) rafId = requestAnimationFrame(loop);
-    }
-    canvas.addEventListener("pointerup", endDrag);
-    canvas.addEventListener("pointercancel", endDrag);
+      reheat();
+    });
 
     var resizeTimer = null;
     window.addEventListener("resize", function () {
       clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(function () { resize(); draw(); }, 150);
+      resizeTimer = setTimeout(function () {
+        resize();
+        nodes.forEach(function (n) {
+          n.x = Math.max(10, Math.min(width - 10, n.x));
+          n.y = Math.max(10, Math.min(height - 10, n.y));
+        });
+        reheat();
+        draw();
+      }, 150);
     });
     new MutationObserver(function () { colors = readColors(); draw(); })
       .observe(document.body, { attributeFilter: ["class"] });

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -24,6 +24,7 @@
     var ctx = canvas.getContext("2d"), wrap = canvas.parentElement;
     var reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
     var colors = readColors(), width = 0, height = 0;
+    var k = 1, tx = 0, ty = 0, dpr = 1;
     var nodesById = {};
     var nodes = Object.keys(data.pages).map(function (id) {
       var p = data.pages[id];
@@ -50,9 +51,8 @@
     function resize() {
       width = wrap.getBoundingClientRect().width;
       height = Math.min(window.innerHeight * 0.7, 600);
-      var dpr = window.devicePixelRatio || 1;
+      dpr = window.devicePixelRatio || 1;
       canvas.width = width * dpr; canvas.height = height * dpr; canvas.style.height = height + "px";
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
     function place() {
       var cx = width / 2, cy = height / 2, maxR = 0.4 * Math.min(width, height);
@@ -64,6 +64,7 @@
     resize(); place();
     var alpha = 1, hovered = null, dragged = null, rafId = null;
     var prevX = 0, prevY = 0, travel = Infinity;
+    var pointers = new Map(), pinchDist = 0, panning = false;
 
     function tick() {
       var cx = width / 2, cy = height / 2, i, j;
@@ -102,9 +103,11 @@
     }
 
     function draw() {
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, width, height);
+      ctx.setTransform(dpr * k, 0, 0, dpr * k, dpr * tx, dpr * ty);
       var neigh = hovered ? neighborsOf(hovered) : null;
-      ctx.strokeStyle = colors.edge; ctx.lineWidth = 1;
+      ctx.strokeStyle = colors.edge; ctx.lineWidth = 1 / k;
       links.forEach(function (l) {
         ctx.globalAlpha = hovered && l.source !== hovered && l.target !== hovered ? 0.25 : 1;
         ctx.beginPath(); ctx.moveTo(l.source.x, l.source.y); ctx.lineTo(l.target.x, l.target.y); ctx.stroke();
@@ -115,12 +118,12 @@
         ctx.fillStyle = colors[n.section] || colors.pages;
         ctx.beginPath(); ctx.arc(n.x, n.y, radius(n), 0, Math.PI * 2); ctx.fill();
       });
-      ctx.globalAlpha = 1; ctx.font = "11px system-ui, sans-serif";
+      ctx.globalAlpha = 1; ctx.font = (11 / k) + "px system-ui, sans-serif";
       ctx.fillStyle = colors.label; ctx.textBaseline = "middle";
       nodes.forEach(function (n) {
         var isNeighbor = n === hovered || (neigh && neigh[n.id]);
         var show = hovered ? isNeighbor : n.degree >= 3;
-        if (show) ctx.fillText(n.title, n.x + radius(n) + 3, n.y);
+        if (show) ctx.fillText(n.title, n.x + radius(n) + 3 / k, n.y);
       });
     }
 
@@ -144,6 +147,7 @@
       var rect = canvas.getBoundingClientRect();
       return { x: e.clientX - rect.left, y: e.clientY - rect.top };
     }
+    function toWorld(p) { return { x: (p.x - tx) / k, y: (p.y - ty) / k }; }
     function hitTest(x, y) {
       var best = null, bestD = Infinity;
       nodes.forEach(function (n) {
@@ -152,41 +156,90 @@
       });
       return best;
     }
+    function zoomAt(sx, sy, factor) {
+      var nk = Math.max(0.5, Math.min(4, k * factor));
+      tx = sx - ((sx - tx) / k) * nk;
+      ty = sy - ((sy - ty) / k) * nk;
+      k = nk;
+      draw();
+    }
 
     canvas.addEventListener("mousemove", function (e) {
-      if (dragged) return;
-      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (dragged || panning || pointers.size > 1) return;
+      var w = toWorld(pointerPos(e)), hit = hitTest(w.x, w.y);
       if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
     });
+    canvas.addEventListener("wheel", function (e) {
+      e.preventDefault();
+      var p = pointerPos(e);
+      zoomAt(p.x, p.y, Math.exp(-e.deltaY * 0.0015));
+    }, { passive: false });
+
     canvas.addEventListener("pointerdown", function (e) {
       var p = pointerPos(e);
-      prevX = p.x; prevY = p.y; travel = 0;
-      var hit = hitTest(p.x, p.y);
-      if (!hit) return;
-      dragged = hit;
+      pointers.set(e.pointerId, p);
       canvas.setPointerCapture(e.pointerId);
+      pinchDist = 0;
+      if (pointers.size === 2) {
+        dragged = null; panning = false; canvas.style.cursor = ""; travel = Infinity;
+        return;
+      }
+      if (pointers.size > 2) return;
+      prevX = p.x; prevY = p.y; travel = 0;
+      var w = toWorld(p), hit = hitTest(w.x, w.y);
+      if (hit) { dragged = hit; }
+      else { panning = true; canvas.style.cursor = "grabbing"; }
     });
     canvas.addEventListener("pointermove", function (e) {
       var p = pointerPos(e);
-      travel += Math.hypot(p.x - prevX, p.y - prevY);
+      if (pointers.has(e.pointerId)) pointers.set(e.pointerId, p);
+      if (pointers.size === 2) {
+        var pts = Array.from(pointers.values());
+        var d = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+        if (pinchDist > 0) zoomAt((pts[0].x + pts[1].x) / 2, (pts[0].y + pts[1].y) / 2, d / pinchDist);
+        pinchDist = d;
+        return;
+      }
+      if (pointers.size > 2) return;
+      var dx = p.x - prevX, dy = p.y - prevY;
+      travel += Math.hypot(dx, dy);
       prevX = p.x; prevY = p.y;
-      if (!dragged) return;
-      dragged.x = p.x; dragged.y = p.y; dragged.vx = 0; dragged.vy = 0;
-      draw();
+      if (dragged) {
+        var w = toWorld(p);
+        dragged.x = w.x; dragged.y = w.y; dragged.vx = 0; dragged.vy = 0;
+        draw();
+      } else if (panning) {
+        tx += dx; ty += dy;
+        draw();
+      }
     });
     canvas.addEventListener("pointerup", function (e) {
+      var wasPinch = pointers.size >= 2;
+      pointers.delete(e.pointerId);
+      pinchDist = 0;
+      if (wasPinch) { travel = Infinity; return; }
       var wasDrag = dragged !== null;
-      dragged = null;
+      dragged = null; panning = false; canvas.style.cursor = "";
       if (travel < 5) {
-        var p = pointerPos(e), hit = hitTest(p.x, p.y);
+        var w = toWorld(pointerPos(e)), hit = hitTest(w.x, w.y);
         if (hit) { window.location.href = hit.id; return; }
       }
       if (wasDrag) reheat();
     });
-    canvas.addEventListener("pointercancel", function () {
-      if (!dragged) return;
-      dragged = null;
-      reheat();
+    canvas.addEventListener("pointercancel", function (e) {
+      pointers.delete(e.pointerId);
+      pinchDist = 0; travel = Infinity;
+      var wasDrag = dragged !== null;
+      dragged = null; panning = false; canvas.style.cursor = "";
+      if (wasDrag) reheat();
+    });
+
+    document.querySelectorAll(".graph-controls button").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var mode = btn.getAttribute("data-zoom");
+        if (mode === "reset") { k = 1; tx = 0; ty = 0; draw(); }
+        else zoomAt(width / 2, height / 2, mode === "in" ? 1.4 : 1 / 1.4);
+      });
     });
 
     var resizeTimer = null;

--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,9 @@ menu:
     # - name: "Archives"
     #   weight: 101
     #   url: "/archives/"
+    - name: "Graph"
+      weight: 101
+      url: "/graph/"
     - name: "Search"
       weight: 102
       url: "/search/"

--- a/content/graph.md
+++ b/content/graph.md
@@ -1,0 +1,14 @@
+---
+title: "Graph"
+description: "Every page on this site and the links between them."
+layout: "graph"
+outputs: ["html", "json"]
+hideMeta: true
+disableShare: true
+comments: false
+showWordCount: false
+showReadingTime: false
+searchHidden: true
+---
+
+Every node is a page; every edge is an internal link. Click a node to visit it.

--- a/layouts/_default/graph.html
+++ b/layouts/_default/graph.html
@@ -20,6 +20,11 @@
       <canvas id="site-graph" role="img"
         aria-label="Map of pages on this site and the links between them"
         data-graph-src="{{ (.OutputFormats.Get "json").RelPermalink }}"></canvas>
+      <div class="graph-controls">
+        <button type="button" data-zoom="in" aria-label="Zoom in">+</button>
+        <button type="button" data-zoom="out" aria-label="Zoom out">−</button>
+        <button type="button" data-zoom="reset" aria-label="Reset view">⌂</button>
+      </div>
     </div>
     <p class="graph-alt-nav">Prefer a list? Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a>.</p>
     <noscript><p>The graph needs JavaScript.</p></noscript>

--- a/layouts/_default/graph.html
+++ b/layouts/_default/graph.html
@@ -1,0 +1,27 @@
+{{- define "main" }}
+{{- with resources.Get "js/graph.js" }}
+{{- $js := . | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
+<script defer src="{{ $js.RelPermalink }}"></script>
+{{- end }}
+<article class="post-single">
+  <header class="post-header">
+    <h1 class="post-title">{{ .Title }}</h1>
+    {{- with .Description }}<div class="post-description">{{ . }}</div>{{- end }}
+  </header>
+  <div class="post-content">
+    {{ .Content }}
+    <div class="graph-legend" aria-hidden="true">
+      <span class="graph-legend__item graph-legend__item--posts">Posts</span>
+      <span class="graph-legend__item graph-legend__item--talks">Talks</span>
+      <span class="graph-legend__item graph-legend__item--newsletter">Newsletter</span>
+      <span class="graph-legend__item graph-legend__item--pages">Pages</span>
+    </div>
+    <div class="graph-canvas-wrap">
+      <canvas id="site-graph" role="img"
+        aria-label="Map of pages on this site and the links between them"
+        data-graph-src="{{ (.OutputFormats.Get "json").RelPermalink }}"></canvas>
+    </div>
+    <noscript><p>The graph needs JavaScript. Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a> instead.</p></noscript>
+  </div>
+</article>
+{{- end }}

--- a/layouts/_default/graph.html
+++ b/layouts/_default/graph.html
@@ -21,7 +21,8 @@
         aria-label="Map of pages on this site and the links between them"
         data-graph-src="{{ (.OutputFormats.Get "json").RelPermalink }}"></canvas>
     </div>
-    <noscript><p>The graph needs JavaScript. Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a> instead.</p></noscript>
+    <p class="graph-alt-nav">Prefer a list? Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a>.</p>
+    <noscript><p>The graph needs JavaScript.</p></noscript>
   </div>
 </article>
 {{- end }}

--- a/layouts/_default/graph.json.json
+++ b/layouts/_default/graph.json.json
@@ -1,0 +1,23 @@
+{{- /* Graph data endpoint (/graph/index.json) for the /graph/ page.
+       Reuses the cached site link index (see functions/link-index.html).
+       Shape: {pages: {permalink: {permalink,title,section}}, graph: {permalink: {in:[], out:[]}}} */ -}}
+{{- $idx := partialCached "functions/link-index.html" site -}}
+{{- $skip := slice "search" "archives" "graph" -}}
+{{- $pagesDict := dict -}}
+{{- $graphDict := dict -}}
+{{- range site.RegularPages -}}
+  {{- if in $skip .Layout }}{{ continue }}{{ end -}}
+  {{- $sec := .Section -}}
+  {{- if eq $sec "" }}{{ $sec = "pages" }}{{ end -}}
+  {{- $pagesDict = merge $pagesDict (dict .RelPermalink (dict "permalink" .RelPermalink "title" (.Title | plainify) "section" $sec)) -}}
+  {{- $out := slice -}}
+  {{- range (index $idx.outgoing .RelPermalink | default slice) -}}
+    {{- if not (in $skip .Layout) -}}{{- $out = $out | append .RelPermalink -}}{{- end -}}
+  {{- end -}}
+  {{- $in := slice -}}
+  {{- range (index $idx.incoming .RelPermalink | default slice) -}}
+    {{- if not (in $skip .Layout) -}}{{- $in = $in | append .RelPermalink -}}{{- end -}}
+  {{- end -}}
+  {{- $graphDict = merge $graphDict (dict .RelPermalink (dict "in" $in "out" $out)) -}}
+{{- end -}}
+{{- dict "pages" $pagesDict "graph" $graphDict | jsonify -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,8 @@
           extend_post_content.html.
        2. The series-nav partial is rendered after the cover, before the
           ToC/content, for posts that belong to a `series` taxonomy term.
+       3. The page-links partial (incoming/outgoing internal links) renders
+          after the tags, before the newsletter form.
        Keep in sync with the theme on PaperMod bumps. */ -}}
 {{- define "main" }}
 
@@ -59,6 +61,7 @@
     {{- end }}
   </ul>
   {{- end }}
+  {{- partial "page-links.html" . }}
 
   {{- partial "extend_post_content.html" . }}
 

--- a/layouts/partials/functions/link-index.html
+++ b/layouts/partials/functions/link-index.html
@@ -5,9 +5,10 @@
        HTML/feeds stay byte-identical to stock output.
        Catches inline links [t](/path) and reference definitions [r]: /path.
        Known, accepted misses: raw HTML <a> tags and links produced by
-       shortcodes; parenthesized external URLs truncate at the first ")"
-       and are dropped by the page-match filter (no internal URL on this
-       site contains parens/spaces).
+       shortcodes; destinations containing parens or spaces are never
+       captured by the inline-link regex at all ([^()\s]+ excludes them),
+       so an internal URL with parens/spaces would also be missed (none
+       exist on this site today).
        CONTRACT: call ONLY as `partialCached "functions/link-index.html" site`
        with NO variant args — a per-page variant would rerun the O(N) scan N times. */ -}}
 {{- $byPermalink := dict -}}

--- a/layouts/partials/functions/link-index.html
+++ b/layouts/partials/functions/link-index.html
@@ -1,0 +1,54 @@
+{{- /* Site-wide link index. Returns dict: "outgoing"/"incoming",
+       each mapping RelPermalink -> Pages.
+       Built by scanning every page's .RawContent for markdown link
+       destinations — deliberately NOT a render hook, so the rendered
+       HTML/feeds stay byte-identical to stock output.
+       Catches inline links [t](/path) and reference definitions [r]: /path.
+       Known, accepted misses: raw HTML <a> tags and links produced by
+       shortcodes; parenthesized external URLs truncate at the first ")"
+       and are dropped by the page-match filter (no internal URL on this
+       site contains parens/spaces).
+       CONTRACT: call ONLY as `partialCached "functions/link-index.html" site`
+       with NO variant args — a per-page variant would rerun the O(N) scan N times. */ -}}
+{{- $byPermalink := dict -}}
+{{- range site.RegularPages -}}{{- $byPermalink = merge $byPermalink (dict .RelPermalink .) -}}{{- end -}}
+{{- $base := urls.Parse site.Home.Permalink -}}
+{{- $out := dict -}}
+{{- $in := dict -}}
+{{- range $source := site.RegularPages -}}
+  {{- $paths := slice -}}
+  {{- $dests := slice -}}
+  {{- range findRESubmatch `\]\(([^()\s]+)(?:\s+"[^"]*")?\)` $source.RawContent -}}
+    {{- $dests = $dests | append (index . 1) -}}
+  {{- end -}}
+  {{- range findRESubmatch `(?m)^\[[^\]]+\]:\s+(\S+)` $source.RawContent -}}
+    {{- $dests = $dests | append (index . 1) -}}
+  {{- end -}}
+  {{- range $d := $dests -}}
+    {{- $u := urls.Parse $d -}}
+    {{- $internal := false -}}
+    {{- if and (eq $u.Scheme "") (eq $u.Host "") (hasPrefix $u.Path "/") -}}
+      {{- $internal = true -}}
+    {{- else if and (eq $u.Host $base.Host) (or (eq $u.Scheme "http") (eq $u.Scheme "https")) -}}
+      {{- $internal = true -}}
+    {{- end -}}
+    {{- if $internal -}}
+      {{- $p := $u.Path -}}
+      {{- if and (ne $p "") (eq (path.Ext $p) "") (not (hasSuffix $p "/")) -}}{{- $p = printf "%s/" $p -}}{{- end -}}
+      {{- if ne $p "" -}}{{- $paths = $paths | append $p -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $targets := slice -}}
+  {{- range (sort (uniq $paths)) -}}
+    {{- $t := index $byPermalink . -}}
+    {{- if and $t (ne $t $source) -}}{{- $targets = $targets | append $t -}}{{- end -}}
+  {{- end -}}
+  {{- if $targets -}}
+    {{- $out = merge $out (dict $source.RelPermalink $targets) -}}
+    {{- range $targets -}}
+      {{- $cur := index $in .RelPermalink | default slice -}}
+      {{- $in = merge $in (dict .RelPermalink ($cur | append $source)) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return (dict "outgoing" $out "incoming" $in) -}}

--- a/layouts/partials/page-links.html
+++ b/layouts/partials/page-links.html
@@ -1,0 +1,32 @@
+{{- /* "Connected pages" nav: outgoing ("Links to") and incoming ("Linked from")
+       internal links, from the cached site link index. Rendered on single pages
+       of posts/talks/newsletter only (single.html). Styles: page-links.css */ -}}
+{{- if in (slice "posts" "talks" "newsletter") .Section }}
+{{- $idx := partialCached "functions/link-index.html" site }}
+{{- $incoming := index $idx.incoming .RelPermalink }}
+{{- $outgoing := index $idx.outgoing .RelPermalink }}
+{{- if or $incoming $outgoing }}
+<nav class="page-links" aria-label="Connected pages">
+  {{- with $outgoing }}
+  <div class="page-links__group">
+    <h3 class="page-links__heading">Links to</h3>
+    <ul class="page-links__list">
+      {{- range sort . "Title" }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      {{- end }}
+    </ul>
+  </div>
+  {{- end }}
+  {{- with $incoming }}
+  <div class="page-links__group">
+    <h3 class="page-links__heading">Linked from</h3>
+    <ul class="page-links__list">
+      {{- range sort . "Title" }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      {{- end }}
+    </ul>
+  </div>
+  {{- end }}
+</nav>
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

Part of the TIL-theme feature port. **This PR now carries two stacked features** — #293 (graph) was merged into this branch, so it ships the automatic link index, the connected-pages nav, **and** the `/graph/` view together.

### 1. Incoming/outgoing links — fully automatic

Unlike the TIL theme's `{{< backlink >}}` shortcode (which only registers links authors explicitly wrap), this scans every page's raw markdown at build time — all existing posts get their link graph with zero content edits. Posts, talks, and newsletter singles render a quiet "Links to / Linked from" nav between the tags and the newsletter form; standalone pages feed the index as sources without rendering the nav.

- `layouts/partials/functions/link-index.html` — cached site-wide index (`partialCached … site`, once per build): scans `.RawContent` for inline links + reference definitions, normalizes (absolute self-URLs, fragments, trailing slashes), inverts for incoming edges. **Deliberately not a render hook**: an earlier hook-based iteration was killed by QA with byte-level evidence (Go template URL escaping drifts from goldmark — `%28%29` parens, `&#43;` in feed contexts); feeds, `/index.json`, and all non-gated pages are byte-identical to master output by construction.
- `layouts/partials/page-links.html`, `assets/css/extended/page-links.css`, one-line `single.html` insertion.

### 2. Content graph at `/graph/`

Where TIL bundles vis-network (hundreds of KB), this is a **hand-rolled dependency-free canvas force sim, ~4.3 KB minified**, loaded only on `/graph/`: nodes colored by section with legend, hover highlights neighbors, click navigates (pointerup with <5px travel — dragging never navigates), nodes drag, resize re-clamps and reheats, dark mode swaps palettes live, `prefers-reduced-motion` renders statically, always-visible list-nav fallback for keyboard/AT users. Data at `/graph/index.json` (page-level `outputs: [html, json]`), reusing the cached link index. One `Graph` menu entry.

## Verification

- Backlinks: 24/24 acceptance ×2 (implementer + independent QA), edge-set regression vs the hook ground truth (58/58 identical), feeds/search-index byte-identity, fragment-preserving hrefs (lychee `--include-fragments` green)
- Graph: 18/18 acceptance + **real-browser Playwright smoke** (canvas renders, click navigates, JSON 200, zero console errors, homepage never requests the graph JS); review fixes (resize clamp, drag/click separation, a11y fallback) re-verified in-browser
- All review threads addressed and resolved

## Review notes

- Netlify preview: a post with links (e.g. `/posts/fosdem-2026/`), `/talks/the-zen-of-prometheus/` ("Linked from"), and `/graph/` in light + dark.
- Known limitation (documented in the partial): raw HTML `<a>` and shortcode-emitted links aren't indexed; paren/space-containing destinations are never captured (none exist internally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV