### PR TITLE
layout: add content graph view at /graph/

### DIFF
--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -29,6 +29,7 @@ body.dark {
   content: ""; display: inline-block; width: 10px; height: 10px;
   border-radius: 50%; margin-right: 6px; vertical-align: baseline;
 }
+.graph-alt-nav { margin: 0.5rem 0 0; font-size: 0.85rem; color: var(--secondary); }
 .graph-legend__item--posts::before      { background: var(--graph-node-posts); }
 .graph-legend__item--talks::before      { background: var(--graph-node-talks); }
 .graph-legend__item--newsletter::before { background: var(--graph-node-newsletter); }

--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -1,0 +1,35 @@
+/* Content-graph page (/graph/): canvas container, legend, node palette.
+   Colors are single-sourced here; graph.js reads them via getComputedStyle. */
+:root {
+  --graph-node-posts: #2e7dd1;
+  --graph-node-talks: #8256d0;
+  --graph-node-newsletter: #347d39;
+  --graph-node-pages: #966600;
+  --graph-edge: rgba(128, 128, 128, 0.35);
+  --graph-label: #555;
+}
+body.dark {
+  --graph-node-posts: #539bf5;
+  --graph-node-talks: #986ee2;
+  --graph-node-newsletter: #57ab5a;
+  --graph-node-pages: #c69026;
+  --graph-edge: rgba(200, 200, 200, 0.25);
+  --graph-label: #aaa;
+}
+.graph-canvas-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--entry);
+  touch-action: none;
+  overflow: hidden;
+}
+.graph-canvas-wrap canvas { display: block; width: 100%; }
+.graph-legend { display: flex; flex-wrap: wrap; gap: 1rem; margin: 0.5rem 0 1rem; font-size: 0.85rem; color: var(--secondary); }
+.graph-legend__item::before {
+  content: ""; display: inline-block; width: 10px; height: 10px;
+  border-radius: 50%; margin-right: 6px; vertical-align: baseline;
+}
+.graph-legend__item--posts::before      { background: var(--graph-node-posts); }
+.graph-legend__item--talks::before      { background: var(--graph-node-talks); }
+.graph-legend__item--newsletter::before { background: var(--graph-node-newsletter); }
+.graph-legend__item--pages::before      { background: var(--graph-node-pages); }

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -1,0 +1,189 @@
+(function () {
+  "use strict";
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var canvas = document.getElementById("site-graph");
+    if (!canvas) return;
+    fetch(canvas.dataset.graphSrc)
+      .then(function (r) { return r.json(); })
+      .then(function (data) { init(canvas, data); })
+      .catch(function (err) { console.warn("graph: failed to load data", err); });
+  });
+
+  function readColors() {
+    var cs = getComputedStyle(document.body);
+    function v(name, fb) { return cs.getPropertyValue(name).trim() || fb; }
+    return {
+      posts: v("--graph-node-posts", "#2e7dd1"), talks: v("--graph-node-talks", "#8256d0"),
+      newsletter: v("--graph-node-newsletter", "#347d39"), pages: v("--graph-node-pages", "#966600"),
+      edge: v("--graph-edge", "rgba(128,128,128,0.35)"), label: v("--graph-label", "#555")
+    };
+  }
+
+  function init(canvas, data) {
+    var ctx = canvas.getContext("2d"), wrap = canvas.parentElement;
+    var reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var colors = readColors(), width = 0, height = 0;
+    var nodesById = {};
+    var nodes = Object.keys(data.pages).map(function (id) {
+      var p = data.pages[id];
+      var n = { id: id, title: p.title, section: p.section, x: 0, y: 0, vx: 0, vy: 0, degree: 0 };
+      nodesById[id] = n;
+      return n;
+    });
+    var seen = {}, links = [];
+    Object.keys(data.graph).forEach(function (id) {
+      var src = nodesById[id];
+      if (!src) return;
+      (data.graph[id].out || []).forEach(function (target) {
+        var tgt = nodesById[target];
+        if (!tgt) return;
+        var key = id < target ? id + "|" + target : target + "|" + id;
+        if (seen[key]) return;
+        seen[key] = true;
+        links.push({ source: src, target: tgt });
+      });
+    });
+    links.forEach(function (l) { l.source.degree++; l.target.degree++; });
+    function radius(n) { return Math.min(3 + 1.5 * Math.sqrt(n.degree), 12); }
+
+    function resize() {
+      width = wrap.getBoundingClientRect().width;
+      height = Math.min(window.innerHeight * 0.7, 600);
+      var dpr = window.devicePixelRatio || 1;
+      canvas.width = width * dpr; canvas.height = height * dpr; canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    function place() {
+      var cx = width / 2, cy = height / 2, maxR = 0.4 * Math.min(width, height);
+      nodes.forEach(function (n) {
+        var ang = Math.random() * Math.PI * 2, rad = Math.random() * maxR;
+        n.x = cx + Math.cos(ang) * rad; n.y = cy + Math.sin(ang) * rad;
+      });
+    }
+    resize(); place();
+    var alpha = 1, hovered = null, dragged = null, rafId = null;
+
+    function tick() {
+      var cx = width / 2, cy = height / 2, i, j;
+      for (i = 0; i < nodes.length; i++) {
+        for (j = i + 1; j < nodes.length; j++) {
+          var a = nodes[i], b = nodes[j], dx = b.x - a.x, dy = b.y - a.y;
+          var d2 = dx * dx + dy * dy || 0.01, d = Math.sqrt(d2), f = (800 / d2) * alpha;
+          var fx = (dx / d) * f, fy = (dy / d) * f;
+          a.vx -= fx; a.vy -= fy; b.vx += fx; b.vy += fy;
+        }
+      }
+      links.forEach(function (l) {
+        var dx = l.target.x - l.source.x, dy = l.target.y - l.source.y;
+        var d = Math.sqrt(dx * dx + dy * dy) || 0.01, f = (d - 80) * 0.04 * alpha;
+        var fx = (dx / d) * f, fy = (dy / d) * f;
+        l.source.vx += fx; l.source.vy += fy; l.target.vx -= fx; l.target.vy -= fy;
+      });
+      nodes.forEach(function (n) {
+        if (n === dragged) return;
+        n.vx += (cx - n.x) * 0.02 * alpha; n.vy += (cy - n.y) * 0.02 * alpha;
+        n.vx *= 0.85; n.vy *= 0.85;
+        n.x += n.vx; n.y += n.vy;
+        n.x = Math.max(10, Math.min(width - 10, n.x));
+        n.y = Math.max(10, Math.min(height - 10, n.y));
+      });
+      alpha *= 0.98;
+    }
+
+    function neighborsOf(n) {
+      var set = {};
+      links.forEach(function (l) {
+        if (l.source === n) set[l.target.id] = true;
+        else if (l.target === n) set[l.source.id] = true;
+      });
+      return set;
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, width, height);
+      var neigh = hovered ? neighborsOf(hovered) : null;
+      ctx.strokeStyle = colors.edge; ctx.lineWidth = 1;
+      links.forEach(function (l) {
+        ctx.globalAlpha = hovered && l.source !== hovered && l.target !== hovered ? 0.25 : 1;
+        ctx.beginPath(); ctx.moveTo(l.source.x, l.source.y); ctx.lineTo(l.target.x, l.target.y); ctx.stroke();
+      });
+      nodes.forEach(function (n) {
+        var isNeighbor = n === hovered || (neigh && neigh[n.id]);
+        ctx.globalAlpha = hovered && !isNeighbor ? 0.25 : 1;
+        ctx.fillStyle = colors[n.section] || colors.pages;
+        ctx.beginPath(); ctx.arc(n.x, n.y, radius(n), 0, Math.PI * 2); ctx.fill();
+      });
+      ctx.globalAlpha = 1; ctx.font = "11px system-ui, sans-serif";
+      ctx.fillStyle = colors.label; ctx.textBaseline = "middle";
+      nodes.forEach(function (n) {
+        var isNeighbor = n === hovered || (neigh && neigh[n.id]);
+        var show = hovered ? isNeighbor : n.degree >= 3;
+        if (show) ctx.fillText(n.title, n.x + radius(n) + 3, n.y);
+      });
+    }
+
+    function loop() {
+      tick(); draw();
+      rafId = alpha < 0.005 ? null : requestAnimationFrame(loop);
+    }
+    if (reduced) {
+      for (var t = 0; t < 300 && alpha >= 0.005; t++) tick();
+      draw();
+    } else {
+      rafId = requestAnimationFrame(loop);
+    }
+
+    function pointerPos(e) {
+      var rect = canvas.getBoundingClientRect();
+      return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+    function hitTest(x, y) {
+      var best = null, bestD = Infinity;
+      nodes.forEach(function (n) {
+        var dx = x - n.x, dy = y - n.y, d2 = dx * dx + dy * dy, r = radius(n) + 6;
+        if (d2 <= r * r && d2 < bestD) { bestD = d2; best = n; }
+      });
+      return best;
+    }
+
+    canvas.addEventListener("mousemove", function (e) {
+      if (dragged) return;
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
+    });
+    canvas.addEventListener("click", function (e) {
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (hit) window.location.href = hit.id;
+    });
+    canvas.addEventListener("pointerdown", function (e) {
+      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      if (!hit) return;
+      dragged = hit;
+      canvas.setPointerCapture(e.pointerId);
+    });
+    canvas.addEventListener("pointermove", function (e) {
+      if (!dragged) return;
+      var p = pointerPos(e);
+      dragged.x = p.x; dragged.y = p.y; dragged.vx = 0; dragged.vy = 0;
+      draw();
+    });
+    function endDrag() {
+      if (!dragged) return;
+      dragged = null;
+      if (reduced) return;
+      alpha = Math.max(alpha, 0.3);
+      if (!rafId) rafId = requestAnimationFrame(loop);
+    }
+    canvas.addEventListener("pointerup", endDrag);
+    canvas.addEventListener("pointercancel", endDrag);
+
+    var resizeTimer = null;
+    window.addEventListener("resize", function () {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(function () { resize(); draw(); }, 150);
+    });
+    new MutationObserver(function () { colors = readColors(); draw(); })
+      .observe(document.body, { attributeFilter: ["class"] });
+  }
+})();

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -63,6 +63,7 @@
     }
     resize(); place();
     var alpha = 1, hovered = null, dragged = null, rafId = null;
+    var prevX = 0, prevY = 0, travel = Infinity;
 
     function tick() {
       var cx = width / 2, cy = height / 2, i, j;
@@ -133,6 +134,11 @@
     } else {
       rafId = requestAnimationFrame(loop);
     }
+    function reheat() {
+      if (reduced) return;
+      alpha = Math.max(alpha, 0.3);
+      if (!rafId) rafId = requestAnimationFrame(loop);
+    }
 
     function pointerPos(e) {
       var rect = canvas.getBoundingClientRect();
@@ -152,36 +158,49 @@
       var p = pointerPos(e), hit = hitTest(p.x, p.y);
       if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
     });
-    canvas.addEventListener("click", function (e) {
-      var p = pointerPos(e), hit = hitTest(p.x, p.y);
-      if (hit) window.location.href = hit.id;
-    });
     canvas.addEventListener("pointerdown", function (e) {
-      var p = pointerPos(e), hit = hitTest(p.x, p.y);
+      var p = pointerPos(e);
+      prevX = p.x; prevY = p.y; travel = 0;
+      var hit = hitTest(p.x, p.y);
       if (!hit) return;
       dragged = hit;
       canvas.setPointerCapture(e.pointerId);
     });
     canvas.addEventListener("pointermove", function (e) {
-      if (!dragged) return;
       var p = pointerPos(e);
+      travel += Math.hypot(p.x - prevX, p.y - prevY);
+      prevX = p.x; prevY = p.y;
+      if (!dragged) return;
       dragged.x = p.x; dragged.y = p.y; dragged.vx = 0; dragged.vy = 0;
       draw();
     });
-    function endDrag() {
+    canvas.addEventListener("pointerup", function (e) {
+      var wasDrag = dragged !== null;
+      dragged = null;
+      if (travel < 5) {
+        var p = pointerPos(e), hit = hitTest(p.x, p.y);
+        if (hit) { window.location.href = hit.id; return; }
+      }
+      if (wasDrag) reheat();
+    });
+    canvas.addEventListener("pointercancel", function () {
       if (!dragged) return;
       dragged = null;
-      if (reduced) return;
-      alpha = Math.max(alpha, 0.3);
-      if (!rafId) rafId = requestAnimationFrame(loop);
-    }
-    canvas.addEventListener("pointerup", endDrag);
-    canvas.addEventListener("pointercancel", endDrag);
+      reheat();
+    });
 
     var resizeTimer = null;
     window.addEventListener("resize", function () {
       clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(function () { resize(); draw(); }, 150);
+      resizeTimer = setTimeout(function () {
+        resize();
+        nodes.forEach(function (n) {
+          n.x = Math.max(10, Math.min(width - 10, n.x));
+          n.y = Math.max(10, Math.min(height - 10, n.y));
+        });
+        reheat();
+        draw();
+      }, 150);
     });
     new MutationObserver(function () { colors = readColors(); draw(); })
       .observe(document.body, { attributeFilter: ["class"] });

--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,9 @@ menu:
     # - name: "Archives"
     #   weight: 101
     #   url: "/archives/"
+    - name: "Graph"
+      weight: 101
+      url: "/graph/"
     - name: "Search"
       weight: 102
       url: "/search/"

--- a/content/graph.md
+++ b/content/graph.md
@@ -1,0 +1,14 @@
+---
+title: "Graph"
+description: "Every page on this site and the links between them."
+layout: "graph"
+outputs: ["html", "json"]
+hideMeta: true
+disableShare: true
+comments: false
+showWordCount: false
+showReadingTime: false
+searchHidden: true
+---
+
+Every node is a page; every edge is an internal link. Click a node to visit it.

--- a/layouts/_default/graph.html
+++ b/layouts/_default/graph.html
@@ -1,0 +1,27 @@
+{{- define "main" }}
+{{- with resources.Get "js/graph.js" }}
+{{- $js := . | js.Build (dict "minify" true "target" "es2018") | fingerprint }}
+<script defer src="{{ $js.RelPermalink }}"></script>
+{{- end }}
+<article class="post-single">
+  <header class="post-header">
+    <h1 class="post-title">{{ .Title }}</h1>
+    {{- with .Description }}<div class="post-description">{{ . }}</div>{{- end }}
+  </header>
+  <div class="post-content">
+    {{ .Content }}
+    <div class="graph-legend" aria-hidden="true">
+      <span class="graph-legend__item graph-legend__item--posts">Posts</span>
+      <span class="graph-legend__item graph-legend__item--talks">Talks</span>
+      <span class="graph-legend__item graph-legend__item--newsletter">Newsletter</span>
+      <span class="graph-legend__item graph-legend__item--pages">Pages</span>
+    </div>
+    <div class="graph-canvas-wrap">
+      <canvas id="site-graph" role="img"
+        aria-label="Map of pages on this site and the links between them"
+        data-graph-src="{{ (.OutputFormats.Get "json").RelPermalink }}"></canvas>
+    </div>
+    <noscript><p>The graph needs JavaScript. Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a> instead.</p></noscript>
+  </div>
+</article>
+{{- end }}

--- a/layouts/_default/graph.html
+++ b/layouts/_default/graph.html
@@ -21,7 +21,8 @@
         aria-label="Map of pages on this site and the links between them"
         data-graph-src="{{ (.OutputFormats.Get "json").RelPermalink }}"></canvas>
     </div>
-    <noscript><p>The graph needs JavaScript. Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a> instead.</p></noscript>
+    <p class="graph-alt-nav">Prefer a list? Browse <a href="/posts/">posts</a>, <a href="/talks/">talks</a> and the <a href="/newsletter/">newsletter</a>.</p>
+    <noscript><p>The graph needs JavaScript.</p></noscript>
   </div>
 </article>
 {{- end }}

--- a/layouts/_default/graph.json.json
+++ b/layouts/_default/graph.json.json
@@ -1,0 +1,23 @@
+{{- /* Graph data endpoint (/graph/index.json) for the /graph/ page.
+       Reuses the cached site link index (see functions/link-index.html).
+       Shape: {pages: {permalink: {permalink,title,section}}, graph: {permalink: {in:[], out:[]}}} */ -}}
+{{- $idx := partialCached "functions/link-index.html" site -}}
+{{- $skip := slice "search" "archives" "graph" -}}
+{{- $pagesDict := dict -}}
+{{- $graphDict := dict -}}
+{{- range site.RegularPages -}}
+  {{- if in $skip .Layout }}{{ continue }}{{ end -}}
+  {{- $sec := .Section -}}
+  {{- if eq $sec "" }}{{ $sec = "pages" }}{{ end -}}
+  {{- $pagesDict = merge $pagesDict (dict .RelPermalink (dict "permalink" .RelPermalink "title" (.Title | plainify) "section" $sec)) -}}
+  {{- $out := slice -}}
+  {{- range (index $idx.outgoing .RelPermalink | default slice) -}}
+    {{- if not (in $skip .Layout) -}}{{- $out = $out | append .RelPermalink -}}{{- end -}}
+  {{- end -}}
+  {{- $in := slice -}}
+  {{- range (index $idx.incoming .RelPermalink | default slice) -}}
+    {{- if not (in $skip .Layout) -}}{{- $in = $in | append .RelPermalink -}}{{- end -}}
+  {{- end -}}
+  {{- $graphDict = merge $graphDict (dict .RelPermalink (dict "in" $in "out" $out)) -}}
+{{- end -}}
+{{- dict "pages" $pagesDict "graph" $graphDict | jsonify -}}


### PR DESCRIPTION
## Summary

Part of the TIL-theme feature port — the content graph, reimagined for this site's minimal-JS policy. Where TIL bundles vis-network (hundreds of KB), this is a **hand-rolled, dependency-free canvas force simulation: 4.1 KB minified**, shipped on `/graph/` only.

- `/graph/` page: every page is a node (colored by section — posts/talks/newsletter/pages — with a legend), every internal link an edge. Hover highlights neighbors, click navigates, nodes drag, labels appear for hubs (degree ≥ 3) and hovered neighborhoods.
- `/graph/index.json`: data endpoint generated by Hugo (page-level `outputs: [html, json]`), reusing the backlinks PR's cached link index — same shape as TIL's contract (`{pages, graph: {in, out}}`).
- Dark mode swaps palettes live (colors single-sourced in CSS custom properties, read at runtime; a MutationObserver catches the theme toggle). `prefers-reduced-motion` renders the settled layout with no animation. Fetch failure degrades to the `<noscript>`-adjacent fallback, no thrown errors.
- One `Graph` menu entry (weight 101).

## Stacking

**Base is `claude/til-backlinks` (#292)** — this PR consumes its `functions/link-index.html` partial. Merge #292 first, then retarget this to `master` (it will then show only the 6 graph files).

## Verification

- 18/18 acceptance checks (implementer) + full independent QA re-run: GREEN
- **Real-browser smoke test** (Playwright + Chromium against the production build): JSON fetch 200, canvas renders non-uniform pixels, hover→pointer cursor, node click navigated to a real talk page, zero console errors/failed requests (sandbox-blocked analytics excluded via a control-page comparison), homepage makes zero graph-JS requests
- Line-by-line review of `graph.js` against the 9-point functional spec: all present, nothing extra, IIFE, no globals, single fetch
- Lighthouse budget untouched by construction: the script tag exists only in the graph layout (verified by grepping every built HTML file)
- `/graph/` JSON: 45 nodes/entries; `/search/`, `/archives/`, and the graph page itself excluded

## Review notes

- Netlify preview: `/graph/` in light + dark, try hover/click/drag; check the graph JSON at `/graph/index.json`.
- The graph page intentionally has no markdown alternate (`outputs` restricted to html+json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV)_