### PR TITLE
docs: document TIL-port features, ignore agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ styles/*
 
 # Newsletter sidecar briefs (raw aggregation data, not for committing)
 content/newsletter/the-unwind/.brief-*.md
+
+# Claude Code agent worktrees (session-local checkouts)
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ make prose              # Alias for vale with a summary count
 - `layouts/_partials/templates/schema_json.html` -- Rich JSON-LD `@graph` (home: WebSite+Person with sameAs; posts/newsletter: BlogPosting+BreadcrumbList; talks: Article; lists: CollectionPage). Replaces PaperMod's stock schema partial; deliberately emits no `articleBody`
 - `layouts/partials/functions/link-index.html` -- Site-wide internal-link index built by scanning `.RawContent` (markdown links + reference definitions). **Contract: call only as `partialCached "functions/link-index.html" site`** — never with variant args, never as plain `partial`. Deliberately NOT a render hook, so rendered HTML/feeds stay byte-identical to stock output
 - `layouts/partials/page-links.html` -- "Links to / Linked from" nav on posts/talks/newsletter singles, fed by the link index
-- `layouts/_default/graph.html` + `layouts/_default/graph.json.json` -- `/graph/` content-graph page and its JSON endpoint (`/graph/index.json`); rendering via dependency-free canvas force sim in `assets/js/graph.js` (~4 KB minified, loads only on that page)
+- `layouts/_default/graph.html` + `layouts/_default/graph.json.json` -- `/graph/` content-graph page and its JSON endpoint (`/graph/index.json`); rendering via dependency-free canvas force sim in `assets/js/graph.js` (~5.5 KB minified, loads only on that page; wheel/pinch zoom, background-drag pan, keyboard-accessible view controls)
 - `layouts/robots.txt` -- Explicitly welcomes AI crawlers, references llms.txt
 
 ### Custom Shortcodes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ make prose              # Alias for vale with a summary count
 - `layouts/partials/comments.html` -- Giscus (GitHub Discussions) comment integration
 - `layouts/partials/home_info.html` -- Custom homepage info block (overrides PaperMod default)
 - `layouts/partials/author.html` -- Custom author bio partial
-- `layouts/_default/list.html` -- Custom homepage with "Recent Notes" section; year-grouped section lists (`/posts/`, `/talks/`) via `GroupByDate "2006"` (home and term pages stay flat)
+- `layouts/_default/list.html` -- Custom homepage with "Recent Notes" section
 - `layouts/_default/list.md` -- Markdown alternate template for list/taxonomy pages (LLM-friendly output)
 - `layouts/_default/single.md` -- Markdown alternate template for single posts (LLM-friendly output)
 - `layouts/_default/_markup/render-image.html` -- Responsive images with WebP srcset generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,15 @@ make prose              # Alias for vale with a summary count
 - `layouts/partials/comments.html` -- Giscus (GitHub Discussions) comment integration
 - `layouts/partials/home_info.html` -- Custom homepage info block (overrides PaperMod default)
 - `layouts/partials/author.html` -- Custom author bio partial
-- `layouts/_default/list.html` -- Custom homepage with "Recent Notes" section
+- `layouts/_default/list.html` -- Custom homepage with "Recent Notes" section; year-grouped section lists (`/posts/`, `/talks/`) via `GroupByDate "2006"` (home and term pages stay flat)
 - `layouts/_default/list.md` -- Markdown alternate template for list/taxonomy pages (LLM-friendly output)
 - `layouts/_default/single.md` -- Markdown alternate template for single posts (LLM-friendly output)
 - `layouts/_default/_markup/render-image.html` -- Responsive images with WebP srcset generation
+- `layouts/_default/_markup/render-blockquote.html` -- GitHub/Obsidian-style admonitions (see Admonitions under Content Conventions)
+- `layouts/_partials/templates/schema_json.html` -- Rich JSON-LD `@graph` (home: WebSite+Person with sameAs; posts/newsletter: BlogPosting+BreadcrumbList; talks: Article; lists: CollectionPage). Replaces PaperMod's stock schema partial; deliberately emits no `articleBody`
+- `layouts/partials/functions/link-index.html` -- Site-wide internal-link index built by scanning `.RawContent` (markdown links + reference definitions). **Contract: call only as `partialCached "functions/link-index.html" site`** — never with variant args, never as plain `partial`. Deliberately NOT a render hook, so rendered HTML/feeds stay byte-identical to stock output
+- `layouts/partials/page-links.html` -- "Links to / Linked from" nav on posts/talks/newsletter singles, fed by the link index
+- `layouts/_default/graph.html` + `layouts/_default/graph.json.json` -- `/graph/` content-graph page and its JSON endpoint (`/graph/index.json`); rendering via dependency-free canvas force sim in `assets/js/graph.js` (~4 KB minified, loads only on that page)
 - `layouts/robots.txt` -- Explicitly welcomes AI crawlers, references llms.txt
 
 ### Custom Shortcodes
@@ -125,6 +130,20 @@ Each category has a distinct purpose, tone, and structure:
 - Blog posts: local images stored in `static/uploads/`, referenced as `/uploads/filename.jpeg`
 - Talks: YouTube thumbnail URLs — `https://img.youtube.com/vi/{VIDEO_ID}/maxresdefault.jpg`
 - Always include `alt` text; `caption` is optional
+
+### Admonitions
+
+GitHub-style alert blockquotes render as tinted admonition boxes with icons (types: `note`, `tip`, `important`, `warning`, `caution`):
+
+```markdown
+> [!NOTE]
+> Body with **markdown**.
+
+> [!tip] Custom Title
+> Obsidian-style custom titles work too.
+```
+
+Rendered by `layouts/_default/_markup/render-blockquote.html`, styled in `assets/css/extended/admonitions.css` (light + dark). Regular blockquotes are unaffected. The raw syntax degrades gracefully on GitHub and in the `/index.md` markdown alternates.
 
 ### Talk Frontmatter
 


### PR DESCRIPTION
## Summary

Companion docs PR for the TIL-theme feature-port series (#289 admonitions, #291 JSON-LD, #292 backlinks, #293 graph; #290 list-UI polish was **closed without merging** and is no longer documented here). **Merge this one last** — it documents behavior those PRs introduce.

- **CLAUDE.md**: new Layout Overrides entries (blockquote render hook, `schema_json` override, `functions/link-index.html` with its `partialCached … site` call contract, `page-links` nav, `/graph/` templates) and a new **Admonitions** authoring section under Content Conventions (`> [!NOTE]` syntax + Obsidian custom titles).
- **.gitignore**: adds `.claude/worktrees/` (Claude Code agent worktrees created during multi-agent sessions; ephemeral checkouts that must never be committed).

## Verification

Docs-only change; production build unaffected (`make production && make verify` untouched by these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV