### PR TITLE
layout: clear graph hover dim when pointer leaves the canvas

### DIFF
--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -169,6 +169,11 @@
       var w = toWorld(pointerPos(e)), hit = hitTest(w.x, w.y);
       if (hit !== hovered) { hovered = hit; canvas.style.cursor = hit ? "pointer" : ""; draw(); }
     });
+    canvas.addEventListener("mouseleave", function () {
+      if (dragged || panning || !hovered) return;
+      hovered = null; canvas.style.cursor = "";
+      draw();
+    });
     canvas.addEventListener("wheel", function (e) {
       e.preventDefault();
       var p = pointerPos(e);


### PR DESCRIPTION
## Summary

Post-merge QA follow-up for the graph (#292). The browser-verification pass on the zoom feature caught one real bug **after** the merge landed: with no `mouseleave` handler, hovering a node and then moving the pointer off the canvas — most easily onto the new zoom controls overlaying its corner — left the whole graph stuck at the 25% hover-dim until you happened to hover another node.

Five-line fix: a guarded `mouseleave` handler that clears the hover state and redraws (skipped mid-drag/pan so it can't fight those interactions). Cherry-picked from the QA commit on the old feature branch (`3aec051`), applied cleanly onto current master.

## Verification

- Reproduced before the fix in the Playwright harness: bright-pixel count collapsed 5351 → 275 on hover and stayed collapsed after moving onto the ⌂ button; reset-view spread ratio read 0.00.
- After the fix: full smoke re-run GREEN — spread ratio 0.97, all zoom probes (keyboard buttons, wheel-no-scroll, zoomed hit-test click, pan, CDP pinch, reset) pass, zero console errors.
- `make production && make verify` green; bundle 5528 bytes (still ~5.5 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nk4sg9P7CsU4GJo64gvgV)_