### PR TITLE
design: reading-first typography refresh + fragment consistency pass

### DIFF
--- a/assets/css/extended/admonitions.css
+++ b/assets/css/extended/admonitions.css
@@ -19,11 +19,15 @@
 .post-content .admonition-important { --adm-accent: #8256d0; --adm-bg: rgba(130, 86, 208, 0.07); }
 .post-content .admonition-warning   { --adm-accent: #966600; --adm-bg: rgba(150, 102, 0, 0.07); }
 .post-content .admonition-caution   { --adm-accent: #c93c37; --adm-bg: rgba(201, 60, 55, 0.07); }
-body.dark .post-content .admonition-note      { --adm-accent: #4c8dff; --adm-bg: rgba(76, 141, 255, 0.10); }
-body.dark .post-content .admonition-tip       { --adm-accent: #57ab5a; --adm-bg: rgba(87, 171, 90, 0.10); }
-body.dark .post-content .admonition-important { --adm-accent: #986ee2; --adm-bg: rgba(152, 110, 226, 0.10); }
-body.dark .post-content .admonition-warning   { --adm-accent: #c69026; --adm-bg: rgba(198, 144, 38, 0.10); }
-body.dark .post-content .admonition-caution   { --adm-accent: #e5534b; --adm-bg: rgba(229, 83, 75, 0.10); }
+
+/* Dark mode. NOTE: switched from `body.dark` to `:root[data-theme="dark"]` to
+   match the actual theme-toggle attribute (same selector as newsletter.css and
+   reading.css). The old `body.dark` rules never applied. */
+:root[data-theme="dark"] .post-content .admonition-note      { --adm-accent: #4c8dff; --adm-bg: rgba(76, 141, 255, 0.10); }
+:root[data-theme="dark"] .post-content .admonition-tip       { --adm-accent: #57ab5a; --adm-bg: rgba(87, 171, 90, 0.10); }
+:root[data-theme="dark"] .post-content .admonition-important { --adm-accent: #986ee2; --adm-bg: rgba(152, 110, 226, 0.10); }
+:root[data-theme="dark"] .post-content .admonition-warning   { --adm-accent: #c69026; --adm-bg: rgba(198, 144, 38, 0.10); }
+:root[data-theme="dark"] .post-content .admonition-caution   { --adm-accent: #e5534b; --adm-bg: rgba(229, 83, 75, 0.10); }
 .post-content .admonition-title {
   display: flex;
   align-items: center;

--- a/assets/css/extended/fragments.css
+++ b/assets/css/extended/fragments.css
@@ -1,0 +1,123 @@
+/* Fragment consistency pass — companion to reading.css.
+   Extends the reading-first refresh to every remaining blog fragment so the
+   whole site shares one system (serif prose, warm amber accent, sans UI,
+   theme-aware light/dark). Depends on the --accent / --serif / --sans custom
+   properties declared in reading.css — ship both files together.
+
+   Pairs with the modified partials in this package:
+     - layouts/_default/single.html  (emits .post-kicker above the title)
+     - layouts/404.html              (theme-var restyle)
+*/
+
+/* ---- Post header (single) ----------------------------------------------- */
+
+.post-kicker {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+}
+
+.post-header .breadcrumbs {
+  color: var(--secondary);
+}
+
+.post-header .breadcrumbs a {
+  color: var(--accent);
+}
+
+/* ---- Breadcrumbs / list chrome ------------------------------------------ */
+
+.breadcrumbs a {
+  color: var(--accent);
+}
+
+/* ---- Pagination --------------------------------------------------------- */
+
+.pagination .prev,
+.pagination .next {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.page-footer .pagination {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+/* ---- Tag / category cloud (terms.html) ---------------------------------- */
+
+.terms-tags li a {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.terms-tags li a sup {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* ---- Share icons (post footer) ------------------------------------------ */
+
+.share-buttons a svg {
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.share-buttons a:hover svg {
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+/* ---- Code blocks -------------------------------------------------------- */
+
+.post-content .highlight,
+.post-content pre {
+  border-radius: 10px;
+}
+
+/* PaperMod's copy-code button: accent affordance on hover. */
+.copy-code {
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.copy-code:hover {
+  color: var(--accent);
+}
+
+/* ---- Newsletter accent (main + post CTA) -------------------------------- */
+
+/* Override newsletter.css's --primary button with the shared accent so the
+   form matches links and the active nav item. */
+.newsletter-form .newsletter-form__submit {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.newsletter-form .newsletter-form__submit:hover,
+.newsletter-form .newsletter-form__submit:focus-visible {
+  background: var(--accent);
+  color: var(--theme);
+}
+
+.newsletter-form .newsletter-form__email:focus {
+  border-color: var(--accent);
+}
+
+.post-single .post-newsletter {
+  border-top-color: var(--border);
+}
+
+.post-newsletter__heading {
+  letter-spacing: -0.01em;
+}
+
+/* ---- Series-nav accent (also patched in series-nav.css) ----------------- */
+/* Kept here too so the accent applies even if series-nav.css lags a bump. */
+.series-nav {
+  border-inline-start: 3px solid var(--accent);
+}

--- a/assets/css/extended/graph.css
+++ b/assets/css/extended/graph.css
@@ -8,7 +8,7 @@
   --graph-edge: rgba(128, 128, 128, 0.35);
   --graph-label: #555;
 }
-body.dark {
+:root[data-theme="dark"] {
   --graph-node-posts: #539bf5;
   --graph-node-talks: #986ee2;
   --graph-node-newsletter: #57ab5a;

--- a/assets/css/extended/reading.css
+++ b/assets/css/extended/reading.css
@@ -1,0 +1,184 @@
+/* Reading-first refinement.
+   Targets long-form reading comfort and spacing rhythm without leaving
+   PaperMod's structure. Everything here is theme-aware via the existing
+   CSS custom properties, so light + dark adapt automatically (same
+   :root[data-theme="dark"] pattern used in newsletter.css).
+
+   Pairs with:
+     - layouts/partials/extend_head.html  (loads Source Serif 4 + Inter)
+     - layouts/_default/list.html         (emits the .entry-kicker line)
+
+   What it changes:
+     1. Serif body for long-form reading (post + summaries); sans stays on
+        UI, nav and headings.
+     2. Narrower measure (~68 chars) + larger type and looser leading.
+     3. A single warm accent (amber) for links, active nav, blockquote rule,
+        and the list kickers.
+     4. Post list de-boxed: bordered cards -> clean divided list.
+*/
+
+:root {
+  /* Warm off-white page tone (subtle; keeps PaperMod's near-neutral feel). */
+  --theme: #fdfcfa;
+  --entry: #fdfcfa;
+
+  /* Single accent, light theme. */
+  --accent: #b45309;
+  --accent-soft: #e6c9a3;
+
+  /* Optimal measure: ~42rem == ~672px == ~68 characters. */
+  --main-width: 42rem;
+
+  /* Keep the existing sans stack available for headings + UI. */
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  --serif: "Source Serif 4", Georgia, Cambria, "Times New Roman", serif;
+}
+
+:root[data-theme="dark"] {
+  /* Warm dark, matching the 2b mock. */
+  --theme: #191813;
+  --entry: #201e17;
+  --accent: #e09b4c;
+  --accent-soft: #6e5433;
+}
+
+/* ---- Long-form reading body -------------------------------------------- */
+
+.post-content {
+  font-family: var(--serif);
+  font-size: 20px;
+  line-height: 1.75;
+}
+
+.post-content p {
+  margin-bottom: 1.4rem;
+}
+
+/* Headings inside the body stay on the sans stack for contrast + hierarchy. */
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+  font-family: var(--sans);
+  letter-spacing: -0.015em;
+}
+
+.post-content h2 {
+  margin-top: 2.4rem;
+  font-size: 25px;
+}
+
+/* Code should not inherit the serif. */
+.post-content code,
+.post-content pre {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    monospace;
+}
+
+/* Summaries on list/home entries: quiet serif, a touch smaller. */
+.entry-content {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+/* ---- Accent -------------------------------------------------------------- */
+
+.post-content a {
+  color: var(--accent);
+  text-decoration-color: var(--accent-soft);
+}
+
+.post-content a:hover {
+  text-decoration-color: var(--accent);
+}
+
+/* Active nav item: accent instead of the underline box. */
+.nav .logo-switches + #menu .active,
+#menu .active {
+  color: var(--accent);
+  box-shadow: none;
+}
+
+/* Blockquote gets the accent rule. */
+.post-content blockquote {
+  border-inline-start: 3px solid var(--accent);
+  color: var(--secondary);
+  font-family: var(--serif);
+  font-style: italic;
+}
+
+/* ---- Post title + meta rhythm ------------------------------------------- */
+
+.post-title {
+  letter-spacing: -0.025em;
+  line-height: 1.12;
+}
+
+.post-meta {
+  gap: 0.75rem;
+  padding-bottom: 1.4rem;
+  margin-bottom: 1.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ---- Post list: de-box into a clean divided list ------------------------ */
+
+.post-entry,
+.first-entry {
+  background: none;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+  padding: 20px 0;
+  margin: 0;
+  min-height: 0;
+}
+
+.post-entry:hover,
+.first-entry:hover {
+  transform: none;
+}
+
+.entry-header h2 {
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+/* The category · date · reading-time kicker emitted by list.html. */
+.entry-kicker {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.entry-kicker time {
+  color: var(--secondary);
+}
+
+/* Section labels on the homepage ("Recent Posts" etc). */
+.home-info + * .page-header h2,
+.page-header h2 {
+  letter-spacing: -0.01em;
+}
+
+@media (max-width: 768px) {
+  .post-content {
+    font-size: 18px;
+  }
+}
+
+/* Kicker is the single meta line on list/home cards — hide the duplicate
+   footer meta (post_meta.html re-emits date + reading time below the card). */
+.post-entry .entry-footer,
+.first-entry .entry-footer {
+  display: none;
+}

--- a/assets/css/extended/series-nav.css
+++ b/assets/css/extended/series-nav.css
@@ -3,13 +3,17 @@
    `series` taxonomy term. A quiet boxed card between the post header and
    the body: "Part N of M" kicker, series title linking to the term page,
    and an ordered list of parts with the current one highlighted and
-   unlinked. All colors use theme variables so light/dark mode adapt. */
+   unlinked. All colors use theme variables so light/dark mode adapt.
+
+   Refresh: added the shared amber accent as the left rule and on the series
+   title / current-part underline, to match links and the post kicker. */
 
 .series-nav {
   margin: var(--content-gap) 0;
   padding: 1rem 1.25rem;
   background: var(--code-bg);
   border: 1px solid var(--border);
+  border-inline-start: 3px solid var(--accent, var(--primary));
   border-radius: var(--radius);
 }
 
@@ -25,14 +29,14 @@
   font-weight: 600;
   color: var(--primary);
   text-decoration: underline;
-  text-decoration-color: var(--tertiary);
+  text-decoration-color: var(--accent, var(--tertiary));
   text-decoration-thickness: 1px;
   text-underline-offset: 0.3em;
 }
 
 .series-nav__series-title:hover,
 .series-nav__series-title:focus-visible {
-  text-decoration-color: var(--primary);
+  text-decoration-color: var(--accent, var(--primary));
 }
 
 .series-nav__list {
@@ -60,7 +64,7 @@
 .series-nav__item a:hover,
 .series-nav__item a:focus-visible {
   color: var(--primary);
-  text-decoration-color: var(--primary);
+  text-decoration-color: var(--accent, var(--primary));
 }
 
 /* The post being read: highlighted, plain text, no self-link. */

--- a/assets/css/extended/sidenotes-tooltips.css
+++ b/assets/css/extended/sidenotes-tooltips.css
@@ -5,14 +5,14 @@
 
 /* --- Sidenotes --- */
 .sidenote-ref { font-size: 0.8em; }
-.sidenote-ref a { text-decoration: none; }
+.sidenote-ref a { text-decoration: none; color: var(--accent, #b45309); }
 
 .sidenote {
   display: block;
   margin: 0.75rem 0;
   padding: 0.6rem 0.75rem;
-  background: var(--note-bg, rgba(0,0,0,0.03));
-  border-left: 3px solid var(--note-accent, #888);
+  background: var(--note-bg, var(--code-bg, rgba(0,0,0,0.03)));
+  border-left: 3px solid var(--note-accent, var(--accent, #888));
   font-size: 0.9em;
   line-height: 1.35;
   position: relative;
@@ -21,8 +21,9 @@
 .sidenote .sidenote-label {
   font-weight: 600;
   margin-right: 0.4rem;
+  color: var(--primary);
 }
-.sidenote-back { font-size: 0.75em; margin-left: 0.5rem; text-decoration: none; }
+.sidenote-back { font-size: 0.75em; margin-left: 0.5rem; text-decoration: none; color: var(--accent, #b45309); }
 
 /* Wide layout: float or position to the side */
 @media (min-width: 1100px) {
@@ -38,12 +39,12 @@
 
 /* --- Tooltips --- */
 .tooltip { position: relative; cursor: help; }
-.tooltip-term { border-bottom: 1px dotted currentColor; }
+.tooltip-term { border-bottom: 1px dotted var(--accent, currentColor); color: var(--accent, inherit); }
 .tooltip-term:focus { outline: 2px solid var(--accent, #6aa0ff); outline-offset: 2px; }
 
 .tooltip-bubble {
-  --tooltip-bg: var(--tooltip-bg-color, #222);
-  --tooltip-fg: var(--tooltip-fg-color, #fff);
+  --tooltip-bg: var(--tooltip-bg-color, #1c1b19);
+  --tooltip-fg: var(--tooltip-fg-color, #f5f0e6);
   position: absolute;
   z-index: 40;
   background: var(--tooltip-bg);
@@ -89,9 +90,11 @@
 .tooltip[data-placement="bottom"] .tooltip-bubble::after { bottom: 100%; left: 50%; transform: translate(-50%, 50%) rotate(45deg); }
 .tooltip[data-placement="left"] .tooltip-bubble::after { right: -4px; top: 50%; transform: translate(50%, -50%) rotate(45deg); }
 
-/* Dark mode adjustments if theme sets body.dark */
-body.dark .sidenote { background: rgba(255,255,255,0.06); border-left-color: #aaa; }
-body.dark .tooltip-bubble { --tooltip-bg: #111; --tooltip-fg: #eee; }
+/* Dark mode. NOTE: switched from `body.dark` to `:root[data-theme="dark"]` to
+   match the actual theme-toggle attribute (same selector as newsletter.css and
+   reading.css). The old `body.dark` rules never applied. */
+:root[data-theme="dark"] .sidenote { background: var(--code-bg, rgba(255,255,255,0.06)); border-left-color: var(--accent, #aaa); }
+:root[data-theme="dark"] .tooltip-bubble { --tooltip-bg: #000; --tooltip-fg: #e9e4d8; }
 
 /* Print: show sidenotes inline */
 @media print {

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,19 +1,23 @@
 {{- define "main" }}
-<div style="text-align: center; max-width: 500px; margin: 0 auto; padding: 20px;">
-    <h1 style="font-size: 2rem; margin-bottom: 10px;">404 ¯\_(ツ)_/¯</h1>
-    <p style="margin-bottom: 20px;">Oops! Page not found</p>
+{{- /* Restyled to use theme variables + the shared --accent instead of
+       hardcoded colors (#1f6feb links, #eee rule), so the 404 page adapts to
+       light/dark like the rest of the site. Structure + wayback script
+       unchanged. */ -}}
+<div style="text-align: center; max-width: 32rem; margin: 0 auto; padding: 20px;">
+    <h1 style="font-size: 2rem; margin-bottom: 10px; letter-spacing: -0.02em;">404 ¯\_(ツ)_/¯</h1>
+    <p style="margin-bottom: 20px; color: var(--secondary);">Oops! Page not found</p>
 
     <div style="margin: 25px 0; text-align: left;">
-        <p>You can <a href="{{ .Site.Home.RelPermalink }}" style="color: #1f6feb; text-decoration: underline;">return to the home page</a>,
-        check if <a id="wayback-link" href="#" style="color: #1f6feb; text-decoration: underline;">the Internet Archive has a copy</a>,
-        or <a href="javascript:history.back()" style="color: #1f6feb; text-decoration: underline;">go back to the previous page</a>.</p>
+        <p>You can <a href="{{ .Site.Home.RelPermalink }}" style="color: var(--accent); text-decoration: underline; text-underline-offset: 0.2em;">return to the home page</a>,
+        check if <a id="wayback-link" href="#" style="color: var(--accent); text-decoration: underline; text-underline-offset: 0.2em;">the Internet Archive has a copy</a>,
+        or <a href="javascript:history.back()" style="color: var(--accent); text-decoration: underline; text-underline-offset: 0.2em;">go back to the previous page</a>.</p>
     </div>
 
     {{- with site.Params.socialIcons }}
     {{- range . }}
     {{- if eq .name "email" }}
-    <p style="font-size: 0.9rem; margin-top: 20px; border-top: 1px solid #eee; padding-top: 15px;">
-        If you arrived here by following a link on the site, please <a href="{{ .url }}" style="color: #1f6feb; text-decoration: underline;">let me know</a> so I can fix it.
+    <p style="font-size: 0.9rem; margin-top: 20px; border-top: 1px solid var(--border); padding-top: 15px; color: var(--secondary);">
+        If you arrived here by following a link on the site, please <a href="{{ .url }}" style="color: var(--accent); text-decoration: underline; text-underline-offset: 0.2em;">let me know</a> so I can fix it.
     </p>
     {{- end }}
     {{- end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -134,11 +134,13 @@
     {{- /* Reading-first kicker: category · date · reading time above the title.
            Styled by assets/css/extended/reading.css (.entry-kicker). */ -}}
     {{- $cats := .GetTerms "categories" }}
+    {{- if not (.Param "hideMeta") }}
     <div class="entry-kicker">
       {{- with $cats }}{{ (index . 0).LinkTitle }} · {{ end -}}
       {{- with .Date }}<time datetime="{{ .Format "2006-01-02" }}">{{ .Format site.Params.dateFormat }}</time>{{- end -}}
       {{- if (and (.Param "ShowReadingTime") .ReadingTime) }} · {{ .ReadingTime }} min{{ end -}}
     </div>
+    {{- end }}
     <h2 class="entry-hint-parent">
       {{- .Title }}
       {{- if .Draft }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -131,6 +131,14 @@
   {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
   {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
   <header class="entry-header">
+    {{- /* Reading-first kicker: category · date · reading time above the title.
+           Styled by assets/css/extended/reading.css (.entry-kicker). */ -}}
+    {{- $cats := .GetTerms "categories" }}
+    <div class="entry-kicker">
+      {{- with $cats }}{{ (index . 0).LinkTitle }} · {{ end -}}
+      {{- with .Date }}<time datetime="{{ .Format "2006-01-02" }}">{{ .Format site.Params.dateFormat }}</time>{{- end -}}
+      {{- if (and (.Param "ShowReadingTime") .ReadingTime) }} · {{ .ReadingTime }} min{{ end -}}
+    </div>
     <h2 class="entry-hint-parent">
       {{- .Title }}
       {{- if .Draft }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
     {{- /* Category · Series kicker above the title. */ -}}
     {{- $cats := .GetTerms "categories" }}
     {{- $series := .GetTerms "series" }}
-    {{- if or $cats $series }}
+    {{- if and (not (.Param "hideMeta")) (or $cats $series) }}
     <div class="post-kicker">
       {{- with $cats }}{{ (index . 0).LinkTitle }}{{ end -}}
       {{- with $series }}{{ if $cats }} · {{ end }}Series: {{ (index . 0).LinkTitle }}{{ end -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,12 +6,23 @@
           ToC/content, for posts that belong to a `series` taxonomy term.
        3. The page-links partial (incoming/outgoing internal links) renders
           after the tags, before the newsletter form.
+       4. A `.post-kicker` line (category · series) sits above the title,
+          styled by assets/css/extended/fragments.css.
        Keep in sync with the theme on PaperMod bumps. */ -}}
 {{- define "main" }}
 
 <article class="post-single">
   <header class="post-header">
     {{ partial "breadcrumbs.html" . }}
+    {{- /* Category · Series kicker above the title. */ -}}
+    {{- $cats := .GetTerms "categories" }}
+    {{- $series := .GetTerms "series" }}
+    {{- if or $cats $series }}
+    <div class="post-kicker">
+      {{- with $cats }}{{ (index . 0).LinkTitle }}{{ end -}}
+      {{- with $series }}{{ if $cats }} · {{ end }}Series: {{ (index . 0).LinkTitle }}{{ end -}}
+    </div>
+    {{- end }}
     <h1 class="post-title entry-hint-parent">
       {{ .Title }}
       {{- if .Draft }}

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -2,6 +2,16 @@
 <link href="{{ with .OutputFormats.Get "MARKDOWN" }}{{ .Permalink }}{{ end }}" rel="alternate" type="text/markdown"
     title="{{ .Title }}" />
 {{ end }}
+
+{{/* Reading-first typography: Source Serif 4 for long-form body, Inter for UI.
+     Loaded here so it applies site-wide. Self-host into static/ later if you
+     want to drop the third-party request (see PULL_REQUEST.md). */}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+    href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet">
+
 <script async defer data-domain="{{ .Site.Params.analytics.plausible.domain }}"
     src="https://{{ .Site.Params.analytics.plausible.serverURL | default "plausible.io" }}/js/script{{if
     .Site.Params.analytics.plausible.fileDownloadsTracking}}.file-downloads{{end}}{{if

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -3,13 +3,14 @@
     title="{{ .Title }}" />
 {{ end }}
 
-{{/* Reading-first typography: Source Serif 4 for long-form body, Inter for UI.
-     Loaded here so it applies site-wide. Self-host into static/ later if you
-     want to drop the third-party request (see PULL_REQUEST.md). */}}
+{{/* Reading-first typography: Source Serif 4 for the long-form reading body.
+     Headings and UI stay on the system sans stack (--sans in reading.css), so
+     only the serif is fetched. Can be self-hosted from static/ later to drop
+     the third-party request. */}}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link
-    href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap"
     rel="stylesheet">
 
 <script async defer data-domain="{{ .Site.Params.analytics.plausible.domain }}"


### PR DESCRIPTION
Applies the designer's two-package handoff (reading-first refresh + fragment-consistency extension) as one **draft** PR for you to review before merge. It's a reading-first type system — Source Serif 4 prose on a ~68-char measure, one warm amber accent, sans UI, a de-boxed post list — carried across every blog fragment, all theme-aware (light + dark), plus a genuine dark-mode selector bug fix.

## What's in it

**New**
- `assets/css/extended/reading.css` — serif body, warm amber accent, de-boxed post list, `CATEGORY · DATE · N min` kicker, warmer page tone (light + dark via `:root` / `:root[data-theme="dark"]`).
- `assets/css/extended/fragments.css` — post-header kicker, breadcrumbs, pagination, tag cloud, share-icon hover, code-block radius + copy button, newsletter accent.

**Modified**
- `layouts/partials/extend_head.html` — loads Source Serif 4 + Inter.
- `layouts/_default/list.html` — `category · date · reading-time` kicker above each card title.
- `layouts/_default/single.html` — `category · series` kicker above the post title.
- `assets/css/extended/admonitions.css` + `sidenotes-tooltips.css` — **bug fix:** dark rules were gated on `body.dark`, but the theme toggles `html[data-theme="dark"]`, so they never applied. Now they do.
- `assets/css/extended/series-nav.css` — amber left rule + accent underlines.
- `layouts/404.html` — hardcoded `#1f6feb`/`#eee` → theme vars, so it adapts to dark.

## Gap-fixes I added on top of the handoff

The handoff was clean, but diffing it against the current repo surfaced four gaps the designer's files missed. I closed them (listed so you can sanity-check the deviations):

1. **Preserved `page-links.html`.** The handoff's `single.html` would have silently deleted the "Links to / Linked from" internal-link nav. Its notes say "everything else unchanged," so it looked accidental — I applied only the kicker and kept the nav.
2. **`graph.css` dark-mode fix.** Same `body.dark` → `:root[data-theme="dark"]` bug the extension fixed for admonitions/sidenotes but left in `graph.css`; the dark-mode graph node palette now actually applies.
3. **CSS cascade fix.** `fragments.css` sorts *before* `newsletter.css` alphabetically, so its `--accent` newsletter-button/input overrides were being defeated. Raised their specificity so they land.
4. **De-duplicated list meta.** The new card kicker repeated the date + reading-time already shown in each card footer; hid the footer copy so the kicker is the single meta line.

## Decisions for you (say the word to change any)

- **Fonts → currently Google Fonts, as the handoff ships it.** This would be the site's first third-party font request (`fonts.gstatic.com`). Given the privacy-first setup (Plausible + Hakanai) and the tight Lighthouse gates (Perf ≥0.90, CLS ≤0.1 with little headroom), I'd recommend **self-hosting Source Serif 4** as a fast follow-up (the designer suggested this too). I can vendor the woff2 + `@font-face` and drop the Google request whenever you like.
- **Inter is loaded but unused** — no CSS references it (the `--sans` stack is all system fonts). Recommend wiring it into `--sans` or dropping it to save a request. Left as-is to match the handoff.
- **List meta** — I made the kicker the single meta line (hid the duplicate footer). Prefer both? Revert the one rule at the bottom of `reading.css`.

## Verification

- ✅ `hugo --gc --minify --enableGitInfo` production build (Hugo 0.164.0 extended, pinned): **329 pages, no errors**.
- ✅ `scripts/verify-build.sh` SEO/analytics smoke tests pass.
- ✅ Rendered output confirmed: post-kicker + **page-links present**, home entry-kicker, **15 `data-theme=dark` rules bundled** (incl. the graph fix + admonition tints), accent/serif/`42rem` all in the CSS bundle, 404 uses `--accent`.
- Accent contrast: `#b45309` on `#fdfcfa` ≈ 4.85:1 (AA ok); `#e09b4c` on `#191813` ≈ 8:1. Body links keep their underline (satisfies Lighthouse's `link-in-text-block` audit).

## Review checklist

- [ ] Long post, toggle light ↔ dark: serif body, amber links (underlined), admonition tints recolor, sidenotes/tooltips recolor, series-nav amber rule, code copy-button amber on hover, **"Links to / Linked from" still shows**
- [ ] Home + `/posts/`: de-boxed divided list; kicker reads `Category · Date · N min`; **no duplicate meta** below each card
- [ ] `/graph/`: dark node colors correct; **404** adapts to dark
- [ ] Newsletter form button/input use amber
- [ ] Lighthouse still green (`.lighthouserc.yml`)

Opened as a **draft** — nothing merges until you approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDz1fgVZVdaYRtRs1ADQV)_