### PR TITLE
fix: warm list-page + panel backgrounds to match the theme

### DIFF
--- a/assets/css/extended/reading.css
+++ b/assets/css/extended/reading.css
@@ -182,3 +182,25 @@
 .first-entry .entry-footer {
   display: none;
 }
+
+/* Warm the list/section/search pages too. PaperMod gives `body.list` a
+   var(--code-bg) background (grayish) to set list pages apart; with the warmer
+   --theme that reads as an inconsistent grey next to single/standalone pages.
+   Override just the page background back to --theme (body.list out-specifies
+   PaperMod's .list) — --code-bg stays grayish for code blocks, as intended. */
+body.list {
+  background: var(--theme);
+}
+
+/* Warm the neutral surface tone too. PaperMod's --code-bg is a cool grey, used
+   as the background for every quiet panel — the TOC (details.toc), series-nav,
+   sidenotes, the newsletter placeholder, pagination and inline code. Against
+   the warm --theme those read as cool-grey patches, the same inconsistency as
+   body.list. Warm it so panels sit as a subtle warm tint above the page. Code
+   BLOCKS use --code-block-bg (dark) and are unaffected. */
+:root {
+  --code-bg: #f4f0e9;
+}
+:root[data-theme="dark"] {
+  --code-bg: #2a2620;
+}


### PR DESCRIPTION
Fixes the light-theme background inconsistency you spotted: **list/section/search pages (home, blog, talks, newsletter, search) looked grayish-white, while single/standalone pages (misc, graph) looked warm.**

## Cause
The reading-first refresh warmed `--theme`/`--entry` to `#fdfcfa`, but PaperMod's `--code-bg` stayed a **cool grey** (`rgb(245,245,245)`). `--code-bg` backs more than code:
- `body.list` — the whole background of list/section/search pages (PaperMod sets it apart with `--code-bg`)
- quiet panels: **TOC (`details.toc`), series-nav, sidenotes, newsletter placeholder, pagination, inline code**

So those surfaces stayed cool-grey while everything else went warm — exactly the split you saw.

## Fix
- `body.list { background: var(--theme) }` — list/section/search pages now match single pages **exactly** (warm `#fdfcfa`). `body.list` out-specifies PaperMod's `.list`, so it wins without `!important`.
- Warm `--code-bg` — light `#f4f0e9`, dark `#2a2620` — so the quiet panels sit as a subtle **warm** tint instead of cool grey.

Code **blocks** are untouched: they use `--code-block-bg` (dark Catppuccin `#24273a`/`rgb(28,29,33)`), which I verified stays as-is.

## "Anywhere else?" — full audit done
I audited every background surface in the built CSS. The only warm/cool inconsistency was `--code-bg` (and the `body.list` page case), both fixed here. Remaining non-theme backgrounds are all intentional: `--code-block-bg` and the Catppuccin syntax colors (code blocks, always dark), and `--entry` (already warm). No other surprises.

## Verification
- ✅ `hugo --gc --minify` build clean.
- ✅ Bundle confirms: `--code-bg` now `#f4f0e9`/`#2a2620`; `--code-block-bg` unchanged; `body.list` → `--theme` present and winning by specificity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDz1fgVZVdaYRtRs1ADQV)_