### PR TITLE
design: accent color for titles (experimental)

### DIFF
--- a/assets/css/extended/title-accent.css
+++ b/assets/css/extended/title-accent.css
@@ -1,4 +1,5 @@
-/* Experimental: accent-colored titles — isolated for easy revert.
+/* Experimental: accent placement (titles, greeting, kickers, social icons).
+   Isolated for easy revert.
    Delete this one file (or revert the PR) to undo. Sorts last in
    css/extended/, so it wins over reading.css's title rules cleanly.
 
@@ -24,4 +25,23 @@
 .post-kicker,
 .entry-kicker {
   color: var(--accent-2);
+}
+
+/* Homepage greeting — "Hey, I'm Kemal" (the ## in content/_index.md). Targeted
+   by its heading anchor (home-only); primary amber accent. */
+#hey-im-kemal {
+  color: var(--accent);
+}
+
+/* Colorize the social icons: amber by default, secondary teal + a subtle lift
+   on hover (ties both accents together). The icons are stroke=currentColor, so
+   `color` tints them. */
+.social-icons a {
+  color: var(--accent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.social-icons a:hover,
+.social-icons a:focus-visible {
+  color: var(--accent-2);
+  transform: translateY(-1px);
 }

--- a/assets/css/extended/title-accent.css
+++ b/assets/css/extended/title-accent.css
@@ -15,3 +15,13 @@
 .entry-header h2 {
   color: var(--accent);
 }
+
+/* Titles now carry the amber --accent, which collides with the kicker (the
+   category/series/date meta line above the title) that also used --accent.
+   Move the kickers to the secondary teal accent (--accent-2, from
+   tags-links-accent.css) so the meta line reads distinct from the title.
+   The .entry-kicker <time> stays --secondary (set in reading.css). */
+.post-kicker,
+.entry-kicker {
+  color: var(--accent-2);
+}

--- a/assets/css/extended/title-accent.css
+++ b/assets/css/extended/title-accent.css
@@ -1,0 +1,17 @@
+/* Experimental: accent-colored titles — isolated for easy revert.
+   Delete this one file (or revert the PR) to undo. Sorts last in
+   css/extended/, so it wins over reading.css's title rules cleanly.
+
+   Contrast: amber #b45309 on #fdfcfa ~4.85:1, #e09b4c on #191813 ~8:1 —
+   well past WCAG AA, and titles are large text (3:1 bar). */
+
+/* Single post / page / graph title (h1). */
+.post-title {
+  color: var(--accent);
+}
+
+/* Post-list entry titles (home, section lists, tag pages). Remove this block
+   if amber on every list card is too much and you want only single titles. */
+.entry-header h2 {
+  color: var(--accent);
+}


### PR DESCRIPTION
Your "one last experiment" — accent-colored titles. Kept as its own PR so you can revert it independently; everything is in one new file (`assets/css/extended/title-accent.css`).

## What it does
- **Single post / page / graph titles** (`.post-title`) → amber `--accent`
- **Post-list entry titles** (`.entry-header h2`, on home / section lists / tag pages) → amber `--accent`

## Notes
- The list-entry block is the bolder call (every card title goes amber). It's a clearly-commented separate block in the file — say the word and I'll drop it so only single-post titles are accented.
- Isolated + sorts last in `css/extended/`, so it wins the title color without `!important`. Revert = delete the file / revert the PR.
- Contrast: amber on the warm background is ~4.85:1 (light) / ~8:1 (dark); titles are large text (3:1 bar), so comfortably WCAG AA.
- **Preview accuracy:** I merged master (incl. the just-merged background fix #298) into this branch, so the Netlify preview shows amber titles on the corrected warm backgrounds. The PR diff is still just the one new file.

## Verify
- ✅ Clean `hugo --gc --minify` build; bundle confirms `.post-title{color:var(--accent)}` and `.entry-header h2{color:var(--accent)}` present and winning the cascade.

Opened as a **draft** for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDz1fgVZVdaYRtRs1ADQV)_