### PR TITLE
feat(promote): support remote URLs + harden buffer wrapper

### DIFF
--- a/.claude/commands/promote-post.md
+++ b/.claude/commands/promote-post.md
@@ -2,12 +2,17 @@
 
 You are a social media copywriter for kakkoyun.me, a staff software engineer's
 personal blog who specialised on observability (especially instrumentation), performance and open-source. The job is creative work only: read each post, craft three
-platform-shaped messages, post them via `buffer-cli`. Validation (draft/date
+platform-shaped messages, post them via `scripts/buffer`. Validation (draft/date
 checks) has already happened upstream in `scripts/find-promotable-posts.sh`.
 
 ## Input
 
-`$ARGUMENTS` = one or more post file paths (e.g., `content/posts/fosdem-2026.md`).
+`$ARGUMENTS` = one or more local file paths **or** external URLs.
+
+- **Local path** (e.g., `content/posts/fosdem-2026.md`) — reads the markdown file, derives the public URL from the slug.
+- **Remote URL** (e.g., `https://opentelemetry.io/blog/2026/foo/`) — fetches the page, uses the provided URL as-is for all platform links.
+
+Both modes run through the same platform rules, humanizer pass, and posting commands.
 
 ## Skills to load before drafting
 
@@ -26,6 +31,8 @@ generic AI tells social posts tend to drift into.
 
 ## For each post
 
+### Local path
+
 1. Read the post markdown file end-to-end (not just frontmatter).
 2. Pull from frontmatter: `title`, `description`, `categories` (single value).
 3. Derive the URL: `https://kakkoyun.me/posts/<filename-without-.md>/`.
@@ -34,7 +41,18 @@ generic AI tells social posts tend to drift into.
    nothing in the post is quotable, lead with a concrete observation instead.
 5. Draft a message for each platform using the rules below.
 6. Run each draft through the humanizer pass (see "Humanizer pass" section).
-7. Post all three via `buffer-cli`.
+7. Post all three via `scripts/buffer`.
+8. Print the summary table at the end.
+
+### Remote URL
+
+1. Fetch the page with WebFetch. Extract the article title and body text.
+2. Use the provided URL as-is for all platform links — do **not** rewrite to `kakkoyun.me`.
+3. Infer authorship context: contributor, co-author, or sole author. Default to contributor voice ("I got to help build / we shipped") unless the context clearly says otherwise.
+4. Lead with **concrete observations** from the fetched content. Do not fabricate verbatim quotes from fetched HTML — fidelity cannot be guaranteed. Pick the sharpest specific claim the post makes.
+5. Draft a message for each platform using the rules below.
+6. Run each draft through the humanizer pass (see "Humanizer pass" section).
+7. Post all three via `scripts/buffer`.
 8. Print the summary table at the end.
 
 ## Platform rules
@@ -115,8 +133,9 @@ harder once.
 ## Quality gates before posting
 
 - No message exceeds its platform's char limit.
-- The quote is verbatim (copy-paste; not paraphrased).
-- URL is `https://kakkoyun.me/posts/<slug>/` — trailing slash, no `.md`.
+- Local posts: the quote is verbatim (copy-paste; not paraphrased).
+- Local posts: URL is `https://kakkoyun.me/posts/<slug>/` — trailing slash, no `.md`.
+- Remote posts: URL is the provided URL, unchanged.
 - Twitter/Bluesky: outer `"text"` matches first thread item exactly.
 - LinkedIn body contains the post URL.
 - Each message reads like a human wrote it specifically for that platform.

--- a/scripts/buffer
+++ b/scripts/buffer
@@ -2,7 +2,28 @@
 # Wrapper: injects BUFFER_AUTH_TOKEN from 1Password if not already set, then execs buffer-cli.
 set -euo pipefail
 
+if ! command -v buffer-cli &>/dev/null; then
+  echo "Error: buffer-cli not found on PATH." >&2
+  echo "Install: gh release download v0.1.0 --repo erickhun/buffer-cli \\" >&2
+  echo "         --pattern 'buffer-darwin-arm64' --output ~/.local/bin/buffer-cli" >&2
+  echo "         && chmod +x ~/.local/bin/buffer-cli" >&2
+  exit 1
+fi
+
 if [ -z "${BUFFER_AUTH_TOKEN:-}" ]; then
+  if ! command -v op &>/dev/null; then
+    echo "Error: 1Password CLI (op) not found. Install: brew install 1password-cli" >&2
+    echo "Or set BUFFER_AUTH_TOKEN directly to skip 1Password." >&2
+    exit 1
+  fi
+
+  if ! op whoami --account my.1password.com &>/dev/null; then
+    echo "Error: 1Password session expired or not signed in." >&2
+    echo "Fix: eval \$(op signin --account my.1password.com)" >&2
+    echo "Or:  export BUFFER_AUTH_TOKEN=<token>" >&2
+    exit 1
+  fi
+
   BUFFER_AUTH_TOKEN="$(op read 'op://Private/Buffer API Token/credential' --account my.1password.com)"
   export BUFFER_AUTH_TOKEN
 fi


### PR DESCRIPTION
## Summary

- `/project:promote-post` now accepts a remote URL in addition to a local `content/posts/` path — useful for co-authored or external posts (e.g. opentelemetry.io)
- Remote mode: fetches page via WebFetch, uses provided URL as-is, defaults to contributor voice, leads with concrete observations rather than verbatim quotes (HTML fidelity can't be guaranteed)
- Quality gates updated to branch on local vs. remote
- `scripts/buffer` pre-flights `buffer-cli` presence, `op` installation, and session state before touching 1Password — gives actionable error messages instead of a cryptic authorization timeout

## Test plan

- [x] `shellcheck scripts/buffer` passes
- [x] Expired session produces: `Error: 1Password session expired or not signed in. Fix: eval $(op signin ...)`
- [x] `/project:promote-post content/posts/<slug>.md` path unchanged (local flow untouched)
- [ ] `/project:promote-post https://external-url/` — manual smoke test: invoke with a remote URL and verify WebFetch, contributor voice, correct URL in posts