### PR TITLE
feat(posts): six draft posts from GopherCon UK 2026 talk

### DIFF
--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -60,7 +60,7 @@ The OTel profiling signal occupies an interesting position in the spec maturity 
 
 The profiler's README is explicit: "Implements the Alpha OTel Profiles signal." Do not read "OTel Collector receiver" and assume this is production-stable in the OTel spec sense. Alpha means evolving, not backward-compatibility-guaranteed.
 
-What the profiler does produce today, reliably: CPU profiling at the OS-thread level, with correct Go function names via `.gopclntab`. goroutine-level profiling (as distinct from OS threads) is not confirmed in the current release. Neither is allocation profiling. The core use case works: always-on CPU flame graphs for production Go services with zero source changes.
+What the profiler does produce today, reliably: CPU profiling at the OS-thread level, with correct Go function names via `.gopclntab`. The current release does not confirm profiling at the goroutine level, as distinct from OS threads. Neither is allocation profiling. The core use case works: always-on CPU flame graphs for production Go services with zero source changes.
 
 ## The third signal
 

--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -1,8 +1,8 @@
 ---
 title: "The third signal: continuous profiling without code changes"
 description: "Why stripped Go binaries still carry enough runtime metadata for eBPF profiling, and where OpenTelemetry's profiling signal fits in a zero-touch observability stack."
-date: 2026-07-31T00:00:00Z
-publishDate: 2026-07-31T00:00:00Z
+date: 2026-09-22T00:00:00Z
+publishDate: 2026-09-22T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -1,0 +1,67 @@
+---
+title: "The third signal: continuous profiling without code changes"
+date: 2026-07-29
+draft: true
+tags: ["go", "observability", "opentelemetry", "ebpf", "profiling"]
+slug: continuous-profiling-go-without-code-changes
+---
+
+Most tools that profile Go binaries have one dependency you can't avoid in production: debug symbols. Strip your binary — as you should, to cut image size and reduce attack surface — and the profiler can't symbolize the stack frames. You get addresses, not function names.
+
+The `opentelemetry-ebpf-profiler` doesn't have this problem. The reason is specific to Go, and it's worth understanding why.
+
+### .gopclntab: the debug info Go can't remove
+
+Go's runtime needs to walk the call stack at any time — for panics, for the garbage collector, for goroutine dumps. It does this using an internal table called `.gopclntab`, the program-counter-to-line-number table. This table maps raw instruction addresses to function names, file names, and line numbers.
+
+The critical property: the runtime always needs `.gopclntab`, so it survives `strip`. Even a fully static, stripped production binary retains this table. As the profiler's own documentation puts it:
+
+> "The information remains present even for fully static and stripped executables and is thus very valuable because it allows us to symbolize and unwind production executables."
+
+This is the opposite of almost every other profiler's situation. Tools that rely on DWARF debug info or frame pointers fail silently on stripped binaries. The eBPF profiler reads `.gopclntab` instead, so it works correctly on exactly the binaries you actually ship.
+
+For C and C++ code, the profiler takes a different path — it uses `.eh_frame` data, the exception handling table, which is also present in stripped binaries. Neither path requires frame pointers or separate debug symbol packages. Your production containers don't need to change.
+
+### What the profiler actually is
+
+The project started as Elastic Universal Profiling Agent. Elastic donated it to OpenTelemetry in June 2024, completing the transfer via [OTel community issue #1918](https://github.com/open-telemetry/community/issues/1918). It now lives at `github.com/open-telemetry/opentelemetry-ebpf-profiler` and ships as an official OpenTelemetry Collector receiver called `otelcol-ebpf-profiler`. The current version tag is `v0.0.202627` — the project uses calendar-week versioning (ISO week 27 of 2026) rather than numbered releases.
+
+The mechanism is straightforward: an eBPF program fires on CPU sample events at the kernel level and reads process-internal data structures from outside the target process. No LD_PRELOAD, no ptrace, no agent injection. The profiler attaches from the kernel side; the profiled application is completely unaware. The README states it plainly: "No need to load agents or libraries into the processes that are being profiled. No need for any reconfiguration, instrumentation or restarts."
+
+You deploy it as a DaemonSet — one instance per node, covering every workload running on that node.
+
+### What "zero code changes" actually means
+
+The profiled applications need nothing. No rebuild, no restart, no SDK import. That part is real.
+
+The profiler node does require elevated privileges: root, or at minimum `CAP_BPF` and `CAP_PERFMON`. You also need a minimum Linux kernel version with eBPF support (check the current README for the exact number before deploying). On macOS, you need a Linux VM or container runtime — eBPF is a Linux kernel feature.
+
+This is a deployment requirement, not a per-service requirement. You run the profiler once per node and it covers everything. That's what makes it useful at scale: one configuration change instruments an entire Kubernetes cluster.
+
+### The signal status: Alpha
+
+The OTel profiling signal occupies an interesting position in the spec maturity matrix.
+
+| Layer | Status |
+|-------|--------|
+| OTel specification (`/docs/specs/otel/profiles/`) | **Alpha** |
+| OTLP wire format (OTLP 1.11.0) | **Development** |
+| Traces / Metrics / Logs (for comparison) | Stable / Stable / Stable |
+
+The profiler's README is explicit: "Implements the Alpha OTel Profiles signal." Do not read "OTel Collector receiver" and assume this is production-stable in the OTel spec sense. Alpha means evolving, not backward-compatibility-guaranteed.
+
+What the profiler does produce today, reliably: CPU profiling at the OS-thread level, with correct Go function names via `.gopclntab`. Goroutine-level profiling (as distinct from OS threads) is not confirmed in the current release. Neither is allocation profiling. The core use case — always-on CPU flame graphs for production Go services, zero source changes — works.
+
+### The third signal
+
+If you're building a zero-touch observability stack for Go, the shape looks like this:
+
+- **OBI** (OpenTelemetry eBPF Instrumentation): traces and RED metrics for HTTP/gRPC, no rebuild required, runtime attach.
+- **otelc** (OTel compile-time instrumentation): granular spans with exact function-level detail, local dev, requires a rebuild.
+- **opentelemetry-ebpf-profiler**: always-on CPU profiles, whole-system, DaemonSet deploy.
+
+These three cover the full signal triad — traces, metrics, profiles — without a single source change in the application code.
+
+The profiler is the piece that closes the loop. Traces tell you a request was slow. Profiles tell you where the CPU actually went during that slow period. Having both signals correlate via OTel's data model (profiles include trace context) means you can pivot from a slow trace directly into the flame graph for that time window.
+
+It's still Alpha. The signal spec will evolve. But the underlying capability — continuous CPU profiling with correct symbolization of stripped Go binaries, deployed as a DaemonSet, exported as OTLP — is real and running in production today.

--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -13,8 +13,7 @@ tags:
   - opentelemetry
   - ebpf
   - profiling
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---
@@ -35,7 +34,7 @@ For C and C++ code, the profiler takes a different path. It uses `.eh_frame` dat
 
 ## What the profiler actually is
 
-The project started as Elastic Universal Profiling Agent. Elastic donated it to OpenTelemetry in June 2024, completing the transfer via [OTel community issue #1918](https://github.com/open-telemetry/community/issues/1918). It now lives at `github.com/open-telemetry/opentelemetry-ebpf-profiler` and ships as an official OpenTelemetry Collector receiver called `otelcol-ebpf-profiler`. The current version tag is `v0.0.202627` — the project uses calendar-week versioning (ISO week 27 of 2026) rather than numbered releases.
+The project started as Elastic Universal Profiling Agent. Elastic donated it to OpenTelemetry in June 2024, completing the transfer via [OTel community issue #1918](https://github.com/open-telemetry/community/issues/1918). It now lives at `github.com/open-telemetry/opentelemetry-ebpf-profiler`. The receiver itself is the `go.opentelemetry.io/ebpf-profiler` Go module; the project also publishes an official Collector distribution built from it, `otelcol-ebpf-profiler`, in `opentelemetry-collector-releases` — that's the supported path, not the same-named test binary that lives in this repo's own `cmd/` directory for internal use only. As of this writing the version tag is `v0.0.202627`, which reads as ISO week 27 of 2026 — the project uses calendar-week versioning rather than numbered releases, so check the repo for the current tag before you deploy.
 
 The mechanism is straightforward: an eBPF program fires on CPU sample events at the kernel level and reads process-internal data structures from outside the target process. No LD_PRELOAD, no ptrace, no agent injection. The profiler attaches from the kernel side; the profiled application is completely unaware. The README states it plainly: "No need to load agents or libraries into the processes that are being profiled. No need for any reconfiguration, instrumentation or restarts."
 

--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -1,8 +1,8 @@
 ---
 title: "The third signal: continuous profiling without code changes"
 description: "Why stripped Go binaries still carry enough runtime metadata for eBPF profiling, and where OpenTelemetry's profiling signal fits in a zero-touch observability stack."
-date: 2026-09-22T00:00:00Z
-publishDate: 2026-09-22T00:00:00Z
+date: 2026-10-23T00:00:00Z
+publishDate: 2026-10-23T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/continuous-profiling-go-without-code-changes.md
+++ b/content/posts/continuous-profiling-go-without-code-changes.md
@@ -1,44 +1,55 @@
 ---
 title: "The third signal: continuous profiling without code changes"
-date: 2026-07-29
+description: "Why stripped Go binaries still carry enough runtime metadata for eBPF profiling, and where OpenTelemetry's profiling signal fits in a zero-touch observability stack."
+date: 2026-07-31T00:00:00Z
+publishDate: 2026-07-31T00:00:00Z
 draft: true
-tags: ["go", "observability", "opentelemetry", "ebpf", "profiling"]
-slug: continuous-profiling-go-without-code-changes
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - ebpf
+  - profiling
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
-Most tools that profile Go binaries have one dependency you can't avoid in production: debug symbols. Strip your binary — as you should, to cut image size and reduce attack surface — and the profiler can't symbolize the stack frames. You get addresses, not function names.
+Most tools that profile Go binaries have one dependency you can't avoid in production: debug symbols. Strip your binary, as you should to cut image size and reduce attack surface, and the profiler can't symbolize the stack frames. You get addresses, not function names.
 
 The `opentelemetry-ebpf-profiler` doesn't have this problem. The reason is specific to Go, and it's worth understanding why.
 
-### .gopclntab: the debug info Go can't remove
+## .gopclntab: the debug info Go can't remove
 
-Go's runtime needs to walk the call stack at any time — for panics, for the garbage collector, for goroutine dumps. It does this using an internal table called `.gopclntab`, the program-counter-to-line-number table. This table maps raw instruction addresses to function names, file names, and line numbers.
+Go's runtime needs to walk the call stack at any time: for panics, for the garbage collector, for goroutine dumps. It does this using an internal table called `.gopclntab`, the program-counter-to-line-number table. This table maps raw instruction addresses to function names, file names, and line numbers.
 
-The critical property: the runtime always needs `.gopclntab`, so it survives `strip`. Even a fully static, stripped production binary retains this table. As the profiler's own documentation puts it:
-
-> "The information remains present even for fully static and stripped executables and is thus very valuable because it allows us to symbolize and unwind production executables."
+The critical property: the runtime always needs `.gopclntab`, so it survives `strip`. Even a fully static, stripped production binary retains this table. The profiler documentation says that table lets it symbolize and unwind production executables even when they are static and stripped.
 
 This is the opposite of almost every other profiler's situation. Tools that rely on DWARF debug info or frame pointers fail silently on stripped binaries. The eBPF profiler reads `.gopclntab` instead, so it works correctly on exactly the binaries you actually ship.
 
-For C and C++ code, the profiler takes a different path — it uses `.eh_frame` data, the exception handling table, which is also present in stripped binaries. Neither path requires frame pointers or separate debug symbol packages. Your production containers don't need to change.
+For C and C++ code, the profiler takes a different path. It uses `.eh_frame` data, the exception handling table, which is also present in stripped binaries. Neither path requires frame pointers or separate debug symbol packages. Your production containers don't need to change.
 
-### What the profiler actually is
+## What the profiler actually is
 
 The project started as Elastic Universal Profiling Agent. Elastic donated it to OpenTelemetry in June 2024, completing the transfer via [OTel community issue #1918](https://github.com/open-telemetry/community/issues/1918). It now lives at `github.com/open-telemetry/opentelemetry-ebpf-profiler` and ships as an official OpenTelemetry Collector receiver called `otelcol-ebpf-profiler`. The current version tag is `v0.0.202627` — the project uses calendar-week versioning (ISO week 27 of 2026) rather than numbered releases.
 
 The mechanism is straightforward: an eBPF program fires on CPU sample events at the kernel level and reads process-internal data structures from outside the target process. No LD_PRELOAD, no ptrace, no agent injection. The profiler attaches from the kernel side; the profiled application is completely unaware. The README states it plainly: "No need to load agents or libraries into the processes that are being profiled. No need for any reconfiguration, instrumentation or restarts."
 
-You deploy it as a DaemonSet — one instance per node, covering every workload running on that node.
+You deploy it as a DaemonSet: one instance per node, covering every workload running on that node.
 
-### What "zero code changes" actually means
+## What "zero code changes" actually means
 
 The profiled applications need nothing. No rebuild, no restart, no SDK import. That part is real.
 
-The profiler node does require elevated privileges: root, or at minimum `CAP_BPF` and `CAP_PERFMON`. You also need a minimum Linux kernel version with eBPF support (check the current README for the exact number before deploying). On macOS, you need a Linux VM or container runtime — eBPF is a Linux kernel feature.
+The profiler node does require extra privileges: root, or at minimum `CAP_BPF` and `CAP_PERFMON`. You also need a minimum Linux kernel version with eBPF support (check the current README for the exact number before deploying). On macOS, you need a Linux VM or container runtime because eBPF is a Linux kernel feature.
 
 This is a deployment requirement, not a per-service requirement. You run the profiler once per node and it covers everything. That's what makes it useful at scale: one configuration change instruments an entire Kubernetes cluster.
 
-### The signal status: Alpha
+## The signal status: Alpha
 
 The OTel profiling signal occupies an interesting position in the spec maturity matrix.
 
@@ -50,18 +61,18 @@ The OTel profiling signal occupies an interesting position in the spec maturity 
 
 The profiler's README is explicit: "Implements the Alpha OTel Profiles signal." Do not read "OTel Collector receiver" and assume this is production-stable in the OTel spec sense. Alpha means evolving, not backward-compatibility-guaranteed.
 
-What the profiler does produce today, reliably: CPU profiling at the OS-thread level, with correct Go function names via `.gopclntab`. Goroutine-level profiling (as distinct from OS threads) is not confirmed in the current release. Neither is allocation profiling. The core use case — always-on CPU flame graphs for production Go services, zero source changes — works.
+What the profiler does produce today, reliably: CPU profiling at the OS-thread level, with correct Go function names via `.gopclntab`. goroutine-level profiling (as distinct from OS threads) is not confirmed in the current release. Neither is allocation profiling. The core use case works: always-on CPU flame graphs for production Go services with zero source changes.
 
-### The third signal
+## The third signal
 
 If you're building a zero-touch observability stack for Go, the shape looks like this:
 
 - **OBI** (OpenTelemetry eBPF Instrumentation): traces and RED metrics for HTTP/gRPC, no rebuild required, runtime attach.
 - **otelc** (OTel compile-time instrumentation): granular spans with exact function-level detail, local dev, requires a rebuild.
-- **opentelemetry-ebpf-profiler**: always-on CPU profiles, whole-system, DaemonSet deploy.
+- **OpenTelemetry eBPF profiler**: always-on CPU profiles, whole-system, DaemonSet deploy.
 
-These three cover the full signal triad — traces, metrics, profiles — without a single source change in the application code.
+These three cover the full signal triad, traces, metrics, and profiles, without a single source change in the application code.
 
-The profiler is the piece that closes the loop. Traces tell you a request was slow. Profiles tell you where the CPU actually went during that slow period. Having both signals correlate via OTel's data model (profiles include trace context) means you can pivot from a slow trace directly into the flame graph for that time window.
+The useful move is concrete: jump from a slow trace to the flame graph for the same time window. Traces tell you a request was slow. Profiles tell you where the CPU actually went during that slow period. Having both signals correlate via OTel's data model (profiles include trace context) means you can pivot from a slow trace directly into the flame graph for that time window.
 
-It's still Alpha. The signal spec will evolve. But the underlying capability — continuous CPU profiling with correct symbolization of stripped Go binaries, deployed as a DaemonSet, exported as OTLP — is real and running in production today.
+It's still Alpha. The signal spec will evolve. But the underlying capability is real and running in production today: continuous CPU profiling with correct symbolization of stripped Go binaries, deployed as a DaemonSet, exported as OTLP.

--- a/content/posts/go-runtime-futures-flight-recording-usdt.md
+++ b/content/posts/go-runtime-futures-flight-recording-usdt.md
@@ -1,0 +1,93 @@
+---
+title: "Go runtime futures: flight recording, USDT, and the instrumentation hook problem"
+date: 2026-07-29
+draft: true
+tags: ["go", "observability", "opentelemetry", "tracing", "usdt", "ebpf"]
+slug: go-runtime-futures-flight-recording-usdt
+---
+
+The honest summary of Go's instrumentation story in 2026: one long-awaited feature shipped, one proof of concept shows what's possible, and two open proposals document gaps that have caused real production problems for years.
+
+### Flight recording shipped in Go 1.25
+
+[golang/go#63185](https://github.com/golang/go/issues/63185) — the flight recorder proposal — is closed. It shipped.
+
+Go 1.25 includes a JFR-style circular buffer tracer in the `runtime/trace` package. Instead of streaming trace data to a file continuously, it keeps the last N seconds of execution trace data in memory and snapshots on demand. The API is a config struct, not setter methods:
+
+```go
+fr := trace.NewFlightRecorder(trace.FlightRecorderConfig{
+    MinAge:   2 * time.Second,
+    MaxBytes: 64 * 1024 * 1024,
+})
+
+if err := fr.Start(); err != nil {
+    log.Fatal(err)
+}
+
+// Later, on a slow request or error:
+var buf bytes.Buffer
+if _, err := fr.WriteTo(&buf); err != nil {
+    log.Println("flight recorder:", err)
+}
+// buf now contains the last ~2 seconds of trace data
+```
+
+The `go.dev/blog/flight-recorder` post (published September 2025) covers the design. One constraint worth knowing: only one goroutine can call `WriteTo` at a time — concurrent snapshots return an error. Set `MinAge` to roughly 2x the time window of the event you're trying to capture.
+
+This is directly useful for production debugging. OBI and the ebpf-profiler tell you something is slow; flight recording tells you what the Go runtime was doing during that window, on demand, without always-on trace overhead. You deploy the flight recorder, wire `WriteTo` to your error handler or a GODEBUG endpoint, and get trace data only when something goes wrong.
+
+### The httptrace gap that breaks HTTP/2 spans
+
+[golang/go#75654](https://github.com/golang/go/issues/75654) is an open proposal for a hook called `GotResponseEnd` on `httptrace.ClientTrace`. It's worth knowing about because the absence of this hook has a concrete, ongoing production impact on OTel Go users.
+
+The gap: there is no reliable, protocol-agnostic hook for when an HTTP client response body is fully consumed. `PutIdleConn` is the workaround OTel Go currently uses to detect response completion — but `PutIdleConn` is never called for HTTP/2 or HTTP/3 connections. The result is that OTel Go client spans never finish on HTTP/2. They hang open indefinitely. This is tracked in [opentelemetry-go-contrib#4876](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4876), and it's still open.
+
+The proposed fix is simple:
+
+```go
+// Add to httptrace.ClientTrace:
+GotResponseEnd func(err error)
+// Fires exactly once per request when resp.Body.Read returns io.EOF,
+// a non-nil error, or the body is closed early.
+```
+
+This gap has existed in some form since [golang/go#16400](https://github.com/golang/go/issues/16400) in 2016. The newer proposal (#75654, filed September 2025) reframes it with the OTel use case as the concrete motivation. No acceptance decision yet.
+
+### #69887: why compile-time instrumentation has rough edges
+
+[golang/go#69887](https://github.com/golang/go/issues/69887) is Romain Marcadier's proposal for improvements to `-toolexec` — the mechanism that Orchestrion and otelc use to intercept the Go compilation pipeline. It documents two specific gaps that explain why these tools have sharper edges than they should.
+
+First: there's no way for a `-toolexec` tool to influence the build cache on a per-package basis. The only hook point forces cache invalidation at the full-build level. Every untouched package gets rebuilt from scratch because there's no way to say "I didn't transform this package, use the cache." This is why `otelc go build` is slower than `go build` even when most of your packages don't need instrumentation.
+
+Second: the toolchain doesn't tell `-toolexec` tools what the full build arguments are. Orchestrion currently crawls its own process tree looking for a parent `go build` invocation and parses its arguments. That's the kind of workaround you write when the API doesn't give you what you need.
+
+Go team member Austin Clements engaged substantively on the issue, confirming the gaps are real. No acceptance verdict yet, but it's on the incoming proposals list.
+
+### USDT: a proof of concept worth watching
+
+USDT (User Statically-Defined Tracing) probes are compiled into a binary as NOP instructions. When unattached, overhead is essentially zero. When a consumer attaches — bpftrace, perf, a custom eBPF program — the NOP is replaced with an INT3 interrupt and the kernel delivers the event. It's the same kernel path as uprobes once attached; the advantage is that the probe sites are stable, named, and documented as part of the binary's interface rather than tied to internal function addresses.
+
+The Go runtime doesn't ship USDT probes. As of late 2024, the Go team was at an initial-inquiry stage on [golang/go#57175](https://github.com/golang/go/issues/57175) with no roadmap commitment.
+
+My `poc_usdt` fork ([github.com/kakkoyun/go/tree/poc_usdt](https://github.com/kakkoyun/go/tree/poc_usdt)) is a proof of concept that adds USDT probes to `net/http`, `database/sql`, `crypto/tls`, and `net` via a `go tool usdt` subcommand. You can build a Go binary from the fork and list its probes:
+
+```bash
+$ go tool usdt list ./myserver
+PROVIDER   NAME                  ADDRESS     ARGUMENTS
+net_http   server_request_start  0x63296c    8@%rsi -8@%r8
+
+$ go tool usdt bpftrace ./myserver > trace.bt
+$ sudo bpftrace trace.bt
+```
+
+Any binary built with the fork gets standard library instrumentation automatically — no SDK import, no application code changes. The probe sites follow the standard `.note.stapsdt` ELF format, so existing eBPF tooling works without modification.
+
+For Go bindings to libstapsdt (for runtime probe creation rather than compile-time), the canonical library is [`github.com/mmcshane/salp`](https://github.com/mmcshane/salp). Note: `github.com/mmcloughlin/salp` returns 404 — it's `mmcshane`, not `mmcloughlin`.
+
+This is still a proof of concept. The fork isn't proposed for upstream acceptance, ARM64 argument parsing in bpftrace has issues, and the salp library has compatibility problems with Go 1.25+. But it demonstrates that the approach is technically sound. The standard library hooks are there; the question is whether the Go team will commit to maintaining them.
+
+### The horizon
+
+Flight recording is the concrete win: it shipped, you can use it today with Go 1.25. The other threads — the httptrace hook gap causing open spans on HTTP/2, the `-toolexec` improvements needed to make compile-time instrumentation production-grade, USDT probes in the standard library — are open proposals with real use cases behind them.
+
+The gap between "Go is easy to operate" and "Go is easy to instrument" is narrowing. It's just narrowing slowly.

--- a/content/posts/go-runtime-futures-flight-recording-usdt.md
+++ b/content/posts/go-runtime-futures-flight-recording-usdt.md
@@ -1,8 +1,8 @@
 ---
 title: "Go runtime futures: flight recording, USDT, and the instrumentation hook problem"
 description: "Go 1.25's flight recorder shipped, HTTP client tracing still has gaps, and USDT probes show one possible future for Go runtime observability."
-date: 2026-08-02T00:00:00Z
-publishDate: 2026-08-02T00:00:00Z
+date: 2026-09-29T00:00:00Z
+publishDate: 2026-09-29T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/go-runtime-futures-flight-recording-usdt.md
+++ b/content/posts/go-runtime-futures-flight-recording-usdt.md
@@ -1,8 +1,8 @@
 ---
 title: "Go runtime futures: flight recording, USDT, and the instrumentation hook problem"
 description: "Go 1.25's flight recorder shipped, HTTP client tracing still has gaps, and USDT probes show one possible future for Go runtime observability."
-date: 2026-09-29T00:00:00Z
-publishDate: 2026-09-29T00:00:00Z
+date: 2026-10-30T00:00:00Z
+publishDate: 2026-10-30T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/go-runtime-futures-flight-recording-usdt.md
+++ b/content/posts/go-runtime-futures-flight-recording-usdt.md
@@ -14,8 +14,7 @@ tags:
   - tracing
   - usdt
   - ebpf
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---
@@ -48,7 +47,7 @@ if _, err := fr.WriteTo(&buf); err != nil {
 
 The `go.dev/blog/flight-recorder` post (published September 2025) covers the design. One constraint worth knowing: only one goroutine can call `WriteTo` at a time; concurrent snapshots return an error. Set `MinAge` to roughly 2x the time window of the event you're trying to capture.
 
-This is directly useful for production debugging. OBI and the eBPF profiler tell you something is slow; flight recording tells you what the Go runtime was doing during that window, on demand, without always-on trace overhead. You deploy the flight recorder, wire `WriteTo` to your error handler or a GODEBUG endpoint, and get trace data only when something goes wrong.
+This is directly useful for production debugging. OBI and the eBPF profiler tell you something is slow; flight recording tells you what the Go runtime was doing during that window, on demand, without always-on trace overhead. You deploy the flight recorder, wire `WriteTo` to your error handler or a debug HTTP endpoint (`net/http/pprof`-style), and get trace data only when something goes wrong.
 
 ## The httptrace gap that breaks HTTP/2 spans
 

--- a/content/posts/go-runtime-futures-flight-recording-usdt.md
+++ b/content/posts/go-runtime-futures-flight-recording-usdt.md
@@ -1,16 +1,30 @@
 ---
 title: "Go runtime futures: flight recording, USDT, and the instrumentation hook problem"
-date: 2026-07-29
+description: "Go 1.25's flight recorder shipped, HTTP client tracing still has gaps, and USDT probes show one possible future for Go runtime observability."
+date: 2026-08-02T00:00:00Z
+publishDate: 2026-08-02T00:00:00Z
 draft: true
-tags: ["go", "observability", "opentelemetry", "tracing", "usdt", "ebpf"]
-slug: go-runtime-futures-flight-recording-usdt
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - tracing
+  - usdt
+  - ebpf
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
 The honest summary of Go's instrumentation story in 2026: one long-awaited feature shipped, one proof of concept shows what's possible, and two open proposals document gaps that have caused real production problems for years.
 
-### Flight recording shipped in Go 1.25
+## Flight recording shipped in Go 1.25
 
-[golang/go#63185](https://github.com/golang/go/issues/63185) — the flight recorder proposal — is closed. It shipped.
+[golang/go#63185](https://github.com/golang/go/issues/63185), the flight recorder proposal, is closed. It shipped.
 
 Go 1.25 includes a JFR-style circular buffer tracer in the `runtime/trace` package. Instead of streaming trace data to a file continuously, it keeps the last N seconds of execution trace data in memory and snapshots on demand. The API is a config struct, not setter methods:
 
@@ -32,15 +46,15 @@ if _, err := fr.WriteTo(&buf); err != nil {
 // buf now contains the last ~2 seconds of trace data
 ```
 
-The `go.dev/blog/flight-recorder` post (published September 2025) covers the design. One constraint worth knowing: only one goroutine can call `WriteTo` at a time — concurrent snapshots return an error. Set `MinAge` to roughly 2x the time window of the event you're trying to capture.
+The `go.dev/blog/flight-recorder` post (published September 2025) covers the design. One constraint worth knowing: only one goroutine can call `WriteTo` at a time; concurrent snapshots return an error. Set `MinAge` to roughly 2x the time window of the event you're trying to capture.
 
-This is directly useful for production debugging. OBI and the ebpf-profiler tell you something is slow; flight recording tells you what the Go runtime was doing during that window, on demand, without always-on trace overhead. You deploy the flight recorder, wire `WriteTo` to your error handler or a GODEBUG endpoint, and get trace data only when something goes wrong.
+This is directly useful for production debugging. OBI and the eBPF profiler tell you something is slow; flight recording tells you what the Go runtime was doing during that window, on demand, without always-on trace overhead. You deploy the flight recorder, wire `WriteTo` to your error handler or a GODEBUG endpoint, and get trace data only when something goes wrong.
 
-### The httptrace gap that breaks HTTP/2 spans
+## The httptrace gap that breaks HTTP/2 spans
 
-[golang/go#75654](https://github.com/golang/go/issues/75654) is an open proposal for a hook called `GotResponseEnd` on `httptrace.ClientTrace`. It's worth knowing about because the absence of this hook has a concrete, ongoing production impact on OTel Go users.
+[golang/go#75654](https://github.com/golang/go/issues/75654) is an open proposal for a hook called `GotResponseEnd` on `httptrace.ClientTrace`. The missing hook matters because the absence of this hook has a concrete, ongoing production impact on OTel Go users.
 
-The gap: there is no reliable, protocol-agnostic hook for when an HTTP client response body is fully consumed. `PutIdleConn` is the workaround OTel Go currently uses to detect response completion — but `PutIdleConn` is never called for HTTP/2 or HTTP/3 connections. The result is that OTel Go client spans never finish on HTTP/2. They hang open indefinitely. This is tracked in [opentelemetry-go-contrib#4876](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4876), and it's still open.
+The gap: there is no reliable, protocol-agnostic hook for when an HTTP client response body is fully consumed. `PutIdleConn` is the workaround OTel Go currently uses to detect response completion, but `PutIdleConn` is never called for HTTP/2 or HTTP/3 connections. The result is that OTel Go client spans never finish on HTTP/2. They hang open indefinitely. This is tracked in [OpenTelemetry Go contrib issue #4876](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4876), and it's still open.
 
 The proposed fix is simple:
 
@@ -53,9 +67,9 @@ GotResponseEnd func(err error)
 
 This gap has existed in some form since [golang/go#16400](https://github.com/golang/go/issues/16400) in 2016. The newer proposal (#75654, filed September 2025) reframes it with the OTel use case as the concrete motivation. No acceptance decision yet.
 
-### #69887: why compile-time instrumentation has rough edges
+## #69887: why compile-time instrumentation has rough edges
 
-[golang/go#69887](https://github.com/golang/go/issues/69887) is Romain Marcadier's proposal for improvements to `-toolexec` — the mechanism that Orchestrion and otelc use to intercept the Go compilation pipeline. It documents two specific gaps that explain why these tools have sharper edges than they should.
+[golang/go#69887](https://github.com/golang/go/issues/69887) is Romain Marcadier's proposal for improvements to `-toolexec`, the mechanism that Orchestrion and otelc use to intercept the Go compilation pipeline. It documents two specific gaps that explain why these tools have sharper edges than they should.
 
 First: there's no way for a `-toolexec` tool to influence the build cache on a per-package basis. The only hook point forces cache invalidation at the full-build level. Every untouched package gets rebuilt from scratch because there's no way to say "I didn't transform this package, use the cache." This is why `otelc go build` is slower than `go build` even when most of your packages don't need instrumentation.
 
@@ -63,13 +77,13 @@ Second: the toolchain doesn't tell `-toolexec` tools what the full build argumen
 
 Go team member Austin Clements engaged substantively on the issue, confirming the gaps are real. No acceptance verdict yet, but it's on the incoming proposals list.
 
-### USDT: a proof of concept worth watching
+## USDT: a proof of concept worth watching
 
-USDT (User Statically-Defined Tracing) probes are compiled into a binary as NOP instructions. When unattached, overhead is essentially zero. When a consumer attaches — bpftrace, perf, a custom eBPF program — the NOP is replaced with an INT3 interrupt and the kernel delivers the event. It's the same kernel path as uprobes once attached; the advantage is that the probe sites are stable, named, and documented as part of the binary's interface rather than tied to internal function addresses.
+USDT (User Statically-Defined Tracing) probes are compiled into a binary as NOP instructions. When unattached, overhead is essentially zero. When a consumer attaches, whether bpftrace, perf, or a custom eBPF program, the NOP is replaced with an INT3 interrupt and the kernel delivers the event. It's the same kernel path as uprobes once attached; the advantage is that the probe sites are stable, named, and documented as part of the binary's interface rather than tied to internal function addresses.
 
 The Go runtime doesn't ship USDT probes. As of late 2024, the Go team was at an initial-inquiry stage on [golang/go#57175](https://github.com/golang/go/issues/57175) with no roadmap commitment.
 
-My `poc_usdt` fork ([github.com/kakkoyun/go/tree/poc_usdt](https://github.com/kakkoyun/go/tree/poc_usdt)) is a proof of concept that adds USDT probes to `net/http`, `database/sql`, `crypto/tls`, and `net` via a `go tool usdt` subcommand. You can build a Go binary from the fork and list its probes:
+My `poc_usdt` fork ([GitHub](https://github.com/kakkoyun/go/tree/poc_usdt)) is a proof of concept that adds USDT probes to `net/http`, `database/sql`, `crypto/tls`, and `net` via a `go tool usdt` subcommand. You can build a Go binary from the fork and list its probes:
 
 ```bash
 $ go tool usdt list ./myserver
@@ -82,12 +96,12 @@ $ sudo bpftrace trace.bt
 
 Any binary built with the fork gets standard library instrumentation automatically — no SDK import, no application code changes. The probe sites follow the standard `.note.stapsdt` ELF format, so existing eBPF tooling works without modification.
 
-For Go bindings to libstapsdt (for runtime probe creation rather than compile-time), the canonical library is [`github.com/mmcshane/salp`](https://github.com/mmcshane/salp). Note: `github.com/mmcloughlin/salp` returns 404 — it's `mmcshane`, not `mmcloughlin`.
+For Go bindings to libstapsdt (for runtime probe creation rather than compile-time), the canonical library is [`github.com/mmcshane/salp`](https://github.com/mmcshane/salp). Note: `github.com/mmcloughlin/salp` returns 404; it is `mmcshane`, not `mmcloughlin`.
 
 This is still a proof of concept. The fork isn't proposed for upstream acceptance, ARM64 argument parsing in bpftrace has issues, and the salp library has compatibility problems with Go 1.25+. But it demonstrates that the approach is technically sound. The standard library hooks are there; the question is whether the Go team will commit to maintaining them.
 
-### The horizon
+## What is already usable
 
-Flight recording is the concrete win: it shipped, you can use it today with Go 1.25. The other threads — the httptrace hook gap causing open spans on HTTP/2, the `-toolexec` improvements needed to make compile-time instrumentation production-grade, USDT probes in the standard library — are open proposals with real use cases behind them.
+Flight recording is the concrete win: it shipped, you can use it today with Go 1.25. The other threads are open proposals with real use cases behind them: the httptrace hook gap causing open spans on HTTP/2, the `-toolexec` improvements needed to make compile-time instrumentation production-grade, and USDT probes in the standard library.
 
 The gap between "Go is easy to operate" and "Go is easy to instrument" is narrowing. It's just narrowing slowly.

--- a/content/posts/obi-ebpf-auto-instrumentation-go.md
+++ b/content/posts/obi-ebpf-auto-instrumentation-go.md
@@ -1,8 +1,8 @@
 ---
 title: "OBI: eBPF auto-instrumentation for Go in production"
 description: "OBI (OpenTelemetry eBPF Instrumentation) instruments Go services with zero code changes inside a specific, well-defined scope. Here is what that scope is and what it costs."
-date: 2026-07-29T00:00:00Z
-publishDate: 2026-07-29T00:00:00Z
+date: 2026-09-08T00:00:00Z
+publishDate: 2026-09-08T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/obi-ebpf-auto-instrumentation-go.md
+++ b/content/posts/obi-ebpf-auto-instrumentation-go.md
@@ -1,34 +1,38 @@
 ---
 title: "OBI: eBPF auto-instrumentation for Go in production"
-date: 2026-07-28
+description: "OBI (OpenTelemetry eBPF Instrumentation) instruments Go services with zero code changes inside a specific, well-defined scope. Here is what that scope is and what it costs."
+date: 2026-07-29T00:00:00Z
+publishDate: 2026-07-29T00:00:00Z
 draft: true
-description: "OBI (OpenTelemetry eBPF Instrumentation) instruments Go services with zero code changes — for a specific, well-defined scope. Here's what that scope is and what it costs."
-tags: ["go", "observability", "opentelemetry", "ebpf"]
-categories: ["engineering"]
-slug: "obi-ebpf-auto-instrumentation-go"
-toc: true
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - ebpf
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
-"Zero code changes" is a phrase that travels far in conference talks and vendor docs. It needs a precise definition before it's useful. OBI (OpenTelemetry eBPF Instrumentation) delivers on the promise — for a specific scope, with specific requirements. Understanding both is the point.
+"Zero code changes" is a phrase that travels far in conference talks and vendor docs. It needs a precise definition before it's useful. OBI (OpenTelemetry eBPF Instrumentation) delivers on the promise within a specific scope and with specific requirements. Understanding both is the point.
 
-### What OBI is
+## What OBI is
 
-OBI is the direct successor to Grafana Beyla. Grafana Labs donated Beyla to the CNCF OpenTelemetry project in 2025, renamed it OBI, and moved all active development there. The current release is **v0.10.0 (2026-06-30)**, still in Development status — the project itself notes that breaking changes between minor releases are expected while it stays at `v0`.
+OBI is the direct successor to Grafana Beyla. Grafana Labs donated Beyla to the CNCF OpenTelemetry project in 2025, renamed it OBI, and moved all active development there. The current release is **v0.10.0 (2026-06-30)**, still in Development status. The project itself notes that breaking changes between minor releases are expected while it stays at `v0`.
 
 Grafana Beyla continues to exist as Grafana Labs' distribution of the upstream OBI project. If you're using Beyla today, you're running a downstream of OBI.
 
 The GitHub repo is `open-telemetry/opentelemetry-ebpf-instrumentation`. Go module: `go.opentelemetry.io/obi`. Apache-2.0.
 
-### How it works
+## How it works
 
-OBI places eBPF uprobes and kprobes at the kernel level. The eBPF programs are JIT-compiled by the Linux kernel to the host architecture (x86-64 or ARM64). For the Go case, OBI hooks into specific library functions — not generic network traffic — which is what gives it library-level span context rather than just raw packets.
+OBI places eBPF uprobes and kprobes at the kernel level. The eBPF programs are JIT-compiled by the Linux kernel to the host architecture (x86-64 or ARM64). For the Go case, OBI hooks into specific library functions, not generic network traffic, which is what gives it library-level span context rather than just raw packets.
 
-For the standard HTTP/gRPC RED metrics (Rate, Errors, Duration):
-
-- No source code changes.
-- No recompilation.
-- No restart of the instrumented service.
-- No agent injected into the process.
+For standard HTTP/gRPC RED metrics, OBI attaches without source changes, recompilation, restarts, or an in-process agent.
 
 You deploy OBI as a DaemonSet (or sidecar), it attaches to the target processes, and spans and metrics start flowing to your OTel collector.
 
@@ -36,9 +40,9 @@ The official docs are explicit about the boundary:
 
 > "Use language agents or manual instrumentation when you need custom spans, application-specific attributes, business events, or other in-process telemetry."
 
-That's a real constraint, not a footnote. OBI cannot generate a span for a specific business transaction, annotate a span with a database query string, or instrument logic that doesn't correspond to a known library call. For those, you still need either manual OTel SDK usage or a compile-time tool like otelc. OBI's value is in the cases where you want standard RED observability across all services on a node without coordinating with every application team.
+The SDK cost shows up where OBI cannot infer business context. OBI cannot generate a span for a specific business transaction, annotate a span with a database query string, or instrument logic that doesn't correspond to a known library call. For those, you still need either manual OTel SDK usage or a compile-time tool like otelc. OBI's value is in the cases where you want standard RED observability across all services on a node without coordinating with every application team.
 
-### What it actually instruments in Go
+## What it actually instruments in Go
 
 OBI provides Go-specific library-level uprobe instrumentation (distinct from just intercepting network traffic) for 13 named libraries as of v0.10.0. The list includes `net/http`, `golang.org/x/net/http2`, `gorilla/mux`, `gin-gonic/gin`, `google.golang.org/grpc`, `go-redis/redis` v8/v9, Kafka (sarama and confluent-kafka-go), and `database/sql`. Full version constraints are in the `SUPPORT_MATRIX.md` file in the v0.10.0 tag.
 
@@ -49,16 +53,16 @@ The precise scope of "zero code changes" for Go:
 | HTTP/gRPC RED metrics | Yes |
 | Library-level spans for the 13 supported libraries | Yes |
 | Trace context propagation across services (for supported protocols) | Yes |
-| Custom spans or business-logic events | No — requires SDK or compile-time tool |
-| SQL query details or parameters | No — requires SDK or compile-time tool |
+| Custom spans or business-logic events | No; requires SDK or compile-time tool |
+| SQL query details or parameters | No; requires SDK or compile-time tool |
 
-This is not a criticism. It's what production-safe, kernel-level instrumentation can actually do. The kernel can see function arguments and return values at library boundaries; it can't synthesize business context that doesn't exist at that level.
+That is the library-bound visibility limit for production-safe, kernel-level instrumentation. The kernel can see function arguments and return values at library boundaries; it can't synthesize business context that doesn't exist at that level.
 
-### What it requires
+## What it requires
 
 The "zero changes to your application" claim comes with requirements on the infrastructure side.
 
-**Kernel version:** Linux 5.8+. There's a RHEL exception — 4.18+ for RHEL 8-family distros with the required eBPF backports. BTF (BPF Type Format) must be enabled; this has been the default on most distros since kernel 5.14.
+**Kernel version:** Linux 5.8+. There's a RHEL exception: 4.18+ for RHEL 8-family distros with the required eBPF backports. BTF (BPF Type Format) must be enabled; this has been the default on most distros since kernel 5.14.
 
 If you're running macOS development environments, OBI requires Linux. You'll need a Linux VM or actual Linux nodes to test it.
 
@@ -73,26 +77,26 @@ If you're running macOS development environments, OBI requires Linux. You'll nee
 | `CAP_DAC_READ_SEARCH` | Reading binaries |
 | `CAP_PERFMON` | Performance monitoring |
 
-A seventh — `CAP_SYS_ADMIN` — is required when Go trace propagation is enabled or when `perf_event_paranoid` is set high. Alternatively, `privileged: true` in Kubernetes works but is broader than necessary.
+A seventh capability, `CAP_SYS_ADMIN`, is required when Go trace propagation is enabled or when `perf_event_paranoid` is set high. Alternatively, `privileged: true` in Kubernetes works but is broader than necessary.
 
-Security teams will scrutinize this list. That's a real operational cost to factor in.
+Security teams will scrutinize this list. That review is the operational cost to factor in.
 
-### Kubernetes deployment
+## Kubernetes deployment
 
 The recommended production model is a **DaemonSet**: one OBI pod per node, instrumenting all workloads on the node. This requires `hostPID: true` so OBI can access all processes. No changes to application pods.
 
-The sidecar model is also supported — one OBI container per application pod, with `shareProcessNamespace: true` and `privileged: true` on the sidecar. More granular control at the cost of efficiency at scale.
+The sidecar model is also supported: one OBI container per application pod, with `shareProcessNamespace: true` and `privileged: true` on the sidecar. More granular control at the cost of efficiency at scale.
 
 For a single cluster of any reasonable size, the DaemonSet is the right choice. You deploy it once and every service on every node gets baseline observability.
 
-### Language scope
+## Language scope
 
 OBI is multi-language at the network-protocol level. Beyond Go, it supports Java (with an embedded Java agent extracted at runtime), .NET, Node.js, Python, Ruby, C, C++, Rust, and GenAI provider SDKs. This means one DaemonSet can cover a polyglot services environment. Go gets special treatment with library-level uprobes; other languages may only get network-level visibility depending on the stack.
 
-### Where it fits
+## Where it fits
 
 The clearest use case for OBI is the "I need baseline observability across services I don't own or can't rebuild right now" scenario. Ship the DaemonSet, get RED metrics and trace spans for all your HTTP/gRPC services, and then decide which services need deeper instrumentation via otelc or the SDK.
 
-OBI and compile-time tools are complementary, not competing. OBI gives you breadth across all languages and doesn't require touching CI pipelines. Compile-time tools like otelc give you depth — custom spans, business logic, stdlib instrumentation — but require a rebuild and, for otelc specifically, Go 1.25+.
+OBI and compile-time tools are complementary, not competing. OBI gives you breadth across all languages and doesn't require touching CI pipelines. Compile-time tools like otelc give you depth: custom spans, business logic, and stdlib instrumentation. They require a rebuild and, for otelc specifically, Go 1.25+.
 
 The caveat worth repeating: OBI is at v0.10.0 with Development status. The feature set is real and production-tested (Grafana Labs ran this in production as Beyla before the donation), but the API stability guarantees are explicitly not there yet. Budget for minor release changes while it matures toward v1.

--- a/content/posts/obi-ebpf-auto-instrumentation-go.md
+++ b/content/posts/obi-ebpf-auto-instrumentation-go.md
@@ -12,8 +12,7 @@ tags:
   - observability
   - opentelemetry
   - ebpf
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---

--- a/content/posts/obi-ebpf-auto-instrumentation-go.md
+++ b/content/posts/obi-ebpf-auto-instrumentation-go.md
@@ -1,8 +1,8 @@
 ---
 title: "OBI: eBPF auto-instrumentation for Go in production"
 description: "OBI (OpenTelemetry eBPF Instrumentation) instruments Go services with zero code changes inside a specific, well-defined scope. Here is what that scope is and what it costs."
-date: 2026-09-08T00:00:00Z
-publishDate: 2026-09-08T00:00:00Z
+date: 2026-10-09T00:00:00Z
+publishDate: 2026-10-09T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/obi-ebpf-auto-instrumentation-go.md
+++ b/content/posts/obi-ebpf-auto-instrumentation-go.md
@@ -1,0 +1,98 @@
+---
+title: "OBI: eBPF auto-instrumentation for Go in production"
+date: 2026-07-28
+draft: true
+description: "OBI (OpenTelemetry eBPF Instrumentation) instruments Go services with zero code changes — for a specific, well-defined scope. Here's what that scope is and what it costs."
+tags: ["go", "observability", "opentelemetry", "ebpf"]
+categories: ["engineering"]
+slug: "obi-ebpf-auto-instrumentation-go"
+toc: true
+---
+
+"Zero code changes" is a phrase that travels far in conference talks and vendor docs. It needs a precise definition before it's useful. OBI (OpenTelemetry eBPF Instrumentation) delivers on the promise — for a specific scope, with specific requirements. Understanding both is the point.
+
+### What OBI is
+
+OBI is the direct successor to Grafana Beyla. Grafana Labs donated Beyla to the CNCF OpenTelemetry project in 2025, renamed it OBI, and moved all active development there. The current release is **v0.10.0 (2026-06-30)**, still in Development status — the project itself notes that breaking changes between minor releases are expected while it stays at `v0`.
+
+Grafana Beyla continues to exist as Grafana Labs' distribution of the upstream OBI project. If you're using Beyla today, you're running a downstream of OBI.
+
+The GitHub repo is `open-telemetry/opentelemetry-ebpf-instrumentation`. Go module: `go.opentelemetry.io/obi`. Apache-2.0.
+
+### How it works
+
+OBI places eBPF uprobes and kprobes at the kernel level. The eBPF programs are JIT-compiled by the Linux kernel to the host architecture (x86-64 or ARM64). For the Go case, OBI hooks into specific library functions — not generic network traffic — which is what gives it library-level span context rather than just raw packets.
+
+For the standard HTTP/gRPC RED metrics (Rate, Errors, Duration):
+
+- No source code changes.
+- No recompilation.
+- No restart of the instrumented service.
+- No agent injected into the process.
+
+You deploy OBI as a DaemonSet (or sidecar), it attaches to the target processes, and spans and metrics start flowing to your OTel collector.
+
+The official docs are explicit about the boundary:
+
+> "Use language agents or manual instrumentation when you need custom spans, application-specific attributes, business events, or other in-process telemetry."
+
+That's a real constraint, not a footnote. OBI cannot generate a span for a specific business transaction, annotate a span with a database query string, or instrument logic that doesn't correspond to a known library call. For those, you still need either manual OTel SDK usage or a compile-time tool like otelc. OBI's value is in the cases where you want standard RED observability across all services on a node without coordinating with every application team.
+
+### What it actually instruments in Go
+
+OBI provides Go-specific library-level uprobe instrumentation (distinct from just intercepting network traffic) for 13 named libraries as of v0.10.0. The list includes `net/http`, `golang.org/x/net/http2`, `gorilla/mux`, `gin-gonic/gin`, `google.golang.org/grpc`, `go-redis/redis` v8/v9, Kafka (sarama and confluent-kafka-go), and `database/sql`. Full version constraints are in the `SUPPORT_MATRIX.md` file in the v0.10.0 tag.
+
+The precise scope of "zero code changes" for Go:
+
+| Scenario | Zero code changes? |
+|---|---|
+| HTTP/gRPC RED metrics | Yes |
+| Library-level spans for the 13 supported libraries | Yes |
+| Trace context propagation across services (for supported protocols) | Yes |
+| Custom spans or business-logic events | No — requires SDK or compile-time tool |
+| SQL query details or parameters | No — requires SDK or compile-time tool |
+
+This is not a criticism. It's what production-safe, kernel-level instrumentation can actually do. The kernel can see function arguments and return values at library boundaries; it can't synthesize business context that doesn't exist at that level.
+
+### What it requires
+
+The "zero changes to your application" claim comes with requirements on the infrastructure side.
+
+**Kernel version:** Linux 5.8+. There's a RHEL exception — 4.18+ for RHEL 8-family distros with the required eBPF backports. BTF (BPF Type Format) must be enabled; this has been the default on most distros since kernel 5.14.
+
+If you're running macOS development environments, OBI requires Linux. You'll need a Linux VM or actual Linux nodes to test it.
+
+**Capabilities:** OBI requires six Linux capabilities in unprivileged mode:
+
+| Capability | Why |
+|---|---|
+| `CAP_BPF` | Core eBPF program loading |
+| `CAP_SYS_PTRACE` | Process inspection |
+| `CAP_NET_RAW` | Network-level probing |
+| `CAP_CHECKPOINT_RESTORE` | Process state access |
+| `CAP_DAC_READ_SEARCH` | Reading binaries |
+| `CAP_PERFMON` | Performance monitoring |
+
+A seventh — `CAP_SYS_ADMIN` — is required when Go trace propagation is enabled or when `perf_event_paranoid` is set high. Alternatively, `privileged: true` in Kubernetes works but is broader than necessary.
+
+Security teams will scrutinize this list. That's a real operational cost to factor in.
+
+### Kubernetes deployment
+
+The recommended production model is a **DaemonSet**: one OBI pod per node, instrumenting all workloads on the node. This requires `hostPID: true` so OBI can access all processes. No changes to application pods.
+
+The sidecar model is also supported — one OBI container per application pod, with `shareProcessNamespace: true` and `privileged: true` on the sidecar. More granular control at the cost of efficiency at scale.
+
+For a single cluster of any reasonable size, the DaemonSet is the right choice. You deploy it once and every service on every node gets baseline observability.
+
+### Language scope
+
+OBI is multi-language at the network-protocol level. Beyond Go, it supports Java (with an embedded Java agent extracted at runtime), .NET, Node.js, Python, Ruby, C, C++, Rust, and GenAI provider SDKs. This means one DaemonSet can cover a polyglot services environment. Go gets special treatment with library-level uprobes; other languages may only get network-level visibility depending on the stack.
+
+### Where it fits
+
+The clearest use case for OBI is the "I need baseline observability across services I don't own or can't rebuild right now" scenario. Ship the DaemonSet, get RED metrics and trace spans for all your HTTP/gRPC services, and then decide which services need deeper instrumentation via otelc or the SDK.
+
+OBI and compile-time tools are complementary, not competing. OBI gives you breadth across all languages and doesn't require touching CI pipelines. Compile-time tools like otelc give you depth — custom spans, business logic, stdlib instrumentation — but require a rebuild and, for otelc specifically, Go 1.25+.
+
+The caveat worth repeating: OBI is at v0.10.0 with Development status. The feature set is real and production-tested (Grafana Labs ran this in production as Beyla before the donation), but the API stability guarantees are explicitly not there yet. Budget for minor release changes while it matures toward v1.

--- a/content/posts/otelc-compile-time-go-traces.md
+++ b/content/posts/otelc-compile-time-go-traces.md
@@ -1,8 +1,8 @@
 ---
 title: "otelc: zero-touch Go traces at compile time"
 description: "otelc is the OTel SIG's compile-time instrumentation tool for Go: distinct from Orchestrion, built from scratch, and now at its first stable release."
-date: 2026-07-30T00:00:00Z
-publishDate: 2026-07-30T00:00:00Z
+date: 2026-09-15T00:00:00Z
+publishDate: 2026-09-15T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/otelc-compile-time-go-traces.md
+++ b/content/posts/otelc-compile-time-go-traces.md
@@ -1,0 +1,92 @@
+---
+title: "otelc: zero-touch Go traces at compile time"
+date: 2026-07-28
+draft: true
+description: "otelc is the OTel SIG's compile-time instrumentation tool for Go — distinct from Orchestrion, built from scratch, and now at its first stable release. Here's what it does and what it requires."
+tags: ["go", "observability", "opentelemetry", "compile-time-instrumentation"]
+categories: ["engineering"]
+slug: "otelc-compile-time-go-traces"
+toc: true
+---
+
+There are two separate compile-time Go instrumentation tools, and they are regularly confused for each other. Getting that distinction right is the prerequisite for understanding either of them.
+
+**DataDog/orchestrion** is Datadog's tool, CLI binary `orchestrion`, defaults to dd-trace-go/v2. It reached GA at v1.0.0 in November 2024 and is currently at v1.11.0 (2026-06-25). It's vendor-agnostic — you can configure it to use OTel SDK — but Datadog maintains it.
+
+**open-telemetry/opentelemetry-go-compile-instrumentation** is the OTel SIG tool, CLI binary `otelc`. It was built from scratch by Datadog and Alibaba working together under the OpenTelemetry umbrella — inspired by Orchestrion, but a separate codebase with separate maintenance. v1.0.1 shipped on 2026-07-14. That's the first non-retracted stable release.
+
+Orchestrion was not donated to OpenTelemetry. It still lives at `github.com/DataDog/orchestrion`. The relationship between the two tools is: shared mechanism, shared inspiration, different codebases and sponsors.
+
+This post covers `otelc`. If you want the official project announcement, I also cross-posted the [OpenTelemetry blog's v1 post](/posts/go-compile-time-instrumentation-v1/) — that's the community-facing milestone story. This post is the practitioner take: what the mechanism actually is, what the constraints are, and when to reach for it.
+
+### The mechanism
+
+Both tools use the same core approach, which the Orchestrion maintainers describe as compile-time-woven Aspect-Oriented Programming. Here's how it works:
+
+Go's build system has a `-toolexec` flag. Normally, `go build` invokes the compiler directly. With `-toolexec`, every invocation of `go tool compile` passes through your wrapper binary first. `otelc` registers itself as that wrapper.
+
+When `otelc` intercepts a compile invocation, it parses each `.go` source file into an AST, applies instrumentation rules (which functions to wrap, which spans to inject, how to propagate context), and hands the rewritten source to the real compiler. The compiler never sees the original; from its perspective, you just wrote the instrumentation code yourself.
+
+From the OTel blog on otelc:
+
+> "hooks into the standard Go toolchain during the build (through its `-toolexec` mechanism) and injects OpenTelemetry instrumentation into your code, its dependencies, and the standard library as they are compiled."
+
+That last part matters: not just your code, but dependencies and stdlib too. If `net/http` needs instrumentation, otelc can inject it at the point where `net/http` gets compiled into your binary.
+
+The result is a binary with OTel spans baked in. No runtime agent, no sidecar, no dynamic injection. At runtime, the instrumented code calls the OTel SDK just as if you'd written the calls manually — because after the AST rewrite, you effectively did.
+
+### Using it
+
+Install:
+
+```bash
+go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
+```
+
+Build your service with otelc wrapping the build command:
+
+```bash
+otelc go build -o myapp .
+```
+
+That's the complete usage change. No `go:generate`, no build tags, no source modifications. The `-toolexec` flag is wired in by `otelc go build` automatically.
+
+For CI, you set `otelc` in `$PATH` and prefix your existing build command. It works with any build system that accepts custom `go build` invocations. No changes to `go.mod` required for the application itself; otelc manages its own dependencies.
+
+### The constraint you need to know
+
+`otelc` requires **Go 1.25+**. This is confirmed from the README badge and is a genuine constraint: services on Go 1.23 or 1.24 cannot use otelc. For those, OBI (no rebuild required) or Orchestrion (check its `go.mod` for minimum version) are the options.
+
+Go 1.25 isn't ancient — at time of writing it's current — but in environments with slow upgrade cycles or pinned toolchains, this will be the first question to answer.
+
+### Why two tools
+
+It's a fair question. The OTel SIG blog post describes it as Datadog and Alibaba having "independently built compile-time Go instrumentation tools and converged." Orchestrion is Datadog's production-tested tool with broad dd-trace-go integration. The SIG decided the right move was to build a new OTel-native tool from scratch rather than donate Orchestrion wholesale, keeping Orchestrion as Datadog's supported product while the SIG owns the OTel-standard version.
+
+The practical implication for users: if you're on the OTel SDK and want vendor-neutral compile-time instrumentation, `otelc` is the right choice. If you're running Datadog APM and want the broadest integration coverage (51 libraries in dd-trace-go's `contrib/`), Orchestrion is battle-tested and default-wired to dd-trace-go/v2.
+
+The mechanism is identical. Choosing between them is mostly about which tracer SDK you're committing to.
+
+### What it instruments
+
+The OTel blog describes otelc as instrumenting "your code, its dependencies, and the standard library." The exact list of supported frameworks for v1.0.1 is in the repository's instrumentation packages. The Orchestrion + dd-trace-go side (which otelc is converging toward) covers HTTP frameworks (net/http, gin, gorilla/mux, chi, echo, fiber), gRPC, database/sql and ORM layers (sqlx, gorm, mongo-driver), Redis (go-redis v6-v9, redigo, rueidis), Kafka, AWS SDK v1/v2, and Kubernetes client-go.
+
+otelc's coverage is growing toward parity. Check the repo's current state for the exact list — it will have changed between when this was written and when you read it.
+
+### Where it fits relative to OBI
+
+OBI and otelc address the same underlying problem — zero source code changes — but from opposite ends.
+
+OBI attaches from outside the process at runtime. It requires no rebuild, works immediately on deployed services, and handles multiple languages from a single DaemonSet. But it's bounded by what eBPF can observe at library boundaries: RED metrics and library-level spans for the 13 Go libraries it supports. It cannot generate custom spans or instrument business logic.
+
+otelc works at build time. It requires a rebuild and Go 1.25+. In exchange, it can instrument anything: stdlib internals, your own functions, dependencies, business logic. The injected spans have the same fidelity as manually written OTel SDK calls, because after the AST rewrite, they are manually written OTel SDK calls — the compiler just doesn't know you didn't type them.
+
+The decision rule I use:
+
+- Already deployed, can't rebuild, need baseline visibility across services → **OBI**
+- Building or rebuilding, want granular spans, on Go 1.25+ → **otelc**
+- Running Datadog APM with the widest framework coverage → **Orchestrion**
+
+For GopherCon UK 2026, otelc landing at v1.0.1 two weeks before the conference is the most timely piece of the story. The first stable release of an OTel-native compile-time Go instrumentation tool is a meaningful moment in the "Go without a single line of code" narrative, even if "without a single line" really means "with one build command substitution and Go 1.25 on your toolchain."
+
+The `-toolexec` mechanism is one of Go's least-discussed build features. It was designed for code coverage and cgo toolchains — the Go team did not plan it as an instrumentation API. It turns out to be exactly the right hook for compile-time AOP anyway.

--- a/content/posts/otelc-compile-time-go-traces.md
+++ b/content/posts/otelc-compile-time-go-traces.md
@@ -1,8 +1,8 @@
 ---
 title: "otelc: zero-touch Go traces at compile time"
 description: "otelc is the OTel SIG's compile-time instrumentation tool for Go: distinct from Orchestrion, built from scratch, and now at its first stable release."
-date: 2026-09-15T00:00:00Z
-publishDate: 2026-09-15T00:00:00Z
+date: 2026-10-16T00:00:00Z
+publishDate: 2026-10-16T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/otelc-compile-time-go-traces.md
+++ b/content/posts/otelc-compile-time-go-traces.md
@@ -1,25 +1,34 @@
 ---
 title: "otelc: zero-touch Go traces at compile time"
-date: 2026-07-28
+description: "otelc is the OTel SIG's compile-time instrumentation tool for Go: distinct from Orchestrion, built from scratch, and now at its first stable release."
+date: 2026-07-30T00:00:00Z
+publishDate: 2026-07-30T00:00:00Z
 draft: true
-description: "otelc is the OTel SIG's compile-time instrumentation tool for Go — distinct from Orchestrion, built from scratch, and now at its first stable release. Here's what it does and what it requires."
-tags: ["go", "observability", "opentelemetry", "compile-time-instrumentation"]
-categories: ["engineering"]
-slug: "otelc-compile-time-go-traces"
-toc: true
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - compile-time-instrumentation
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
-There are two separate compile-time Go instrumentation tools, and they are regularly confused for each other. Getting that distinction right is the prerequisite for understanding either of them.
+Two separate compile-time Go instrumentation tools are regularly confused for each other. Getting that distinction right is the prerequisite for understanding either of them.
 
-**DataDog/orchestrion** is Datadog's tool, CLI binary `orchestrion`, defaults to dd-trace-go/v2. It reached GA at v1.0.0 in November 2024 and is currently at v1.11.0 (2026-06-25). It's vendor-agnostic — you can configure it to use OTel SDK — but Datadog maintains it.
+**Datadog Orchestrion** is Datadog's tool, CLI binary `orchestrion`, defaults to dd-trace-go/v2. It reached GA at v1.0.0 in November 2024 and is currently at v1.11.0 (2026-06-25). It is vendor-agnostic: you can configure it to use the OTel SDK, but Datadog maintains it.
 
-**open-telemetry/opentelemetry-go-compile-instrumentation** is the OTel SIG tool, CLI binary `otelc`. It was built from scratch by Datadog and Alibaba working together under the OpenTelemetry umbrella — inspired by Orchestrion, but a separate codebase with separate maintenance. v1.0.1 shipped on 2026-07-14. That's the first non-retracted stable release.
+**OpenTelemetry Go compile instrumentation** is the OTel SIG tool, CLI binary `otelc`. It was built from scratch by Datadog and Alibaba working together under the OpenTelemetry umbrella. It was inspired by Orchestrion, but it is a separate codebase with separate maintenance. v1.0.1 shipped on 2026-07-14. That's the first non-retracted stable release.
 
 Orchestrion was not donated to OpenTelemetry. It still lives at `github.com/DataDog/orchestrion`. The relationship between the two tools is: shared mechanism, shared inspiration, different codebases and sponsors.
 
-This post covers `otelc`. If you want the official project announcement, I also cross-posted the [OpenTelemetry blog's v1 post](/posts/go-compile-time-instrumentation-v1/) — that's the community-facing milestone story. This post is the practitioner take: what the mechanism actually is, what the constraints are, and when to reach for it.
+The confusion matters because the two tools make different promises: Orchestrion optimizes for Datadog APM users, while otelc optimizes for OTel-native builds. If you want the official project announcement, I also cross-posted the [OpenTelemetry blog's v1 post](/posts/go-compile-time-instrumentation-v1/) — that's the community-facing milestone story. This post is the practitioner take: what the mechanism actually is, what the constraints are, and when to reach for it.
 
-### The mechanism
+## The mechanism
 
 Both tools use the same core approach, which the Orchestrion maintainers describe as compile-time-woven Aspect-Oriented Programming. Here's how it works:
 
@@ -31,11 +40,11 @@ From the OTel blog on otelc:
 
 > "hooks into the standard Go toolchain during the build (through its `-toolexec` mechanism) and injects OpenTelemetry instrumentation into your code, its dependencies, and the standard library as they are compiled."
 
-That last part matters: not just your code, but dependencies and stdlib too. If `net/http` needs instrumentation, otelc can inject it at the point where `net/http` gets compiled into your binary.
+That last part matters: your code, dependencies, and the standard library. If `net/http` needs instrumentation, otelc can inject it at the point where `net/http` gets compiled into your binary.
 
-The result is a binary with OTel spans baked in. No runtime agent, no sidecar, no dynamic injection. At runtime, the instrumented code calls the OTel SDK just as if you'd written the calls manually — because after the AST rewrite, you effectively did.
+The result is a binary with OTel spans baked in. No runtime agent, no sidecar, no dynamic injection. At runtime, the instrumented code calls the OTel SDK just as if you'd written the calls manually. After the AST rewrite, you effectively did.
 
-### Using it
+## Using it
 
 Install:
 
@@ -53,13 +62,13 @@ That's the complete usage change. No `go:generate`, no build tags, no source mod
 
 For CI, you set `otelc` in `$PATH` and prefix your existing build command. It works with any build system that accepts custom `go build` invocations. No changes to `go.mod` required for the application itself; otelc manages its own dependencies.
 
-### The constraint you need to know
+## The constraint you need to know
 
 `otelc` requires **Go 1.25+**. This is confirmed from the README badge and is a genuine constraint: services on Go 1.23 or 1.24 cannot use otelc. For those, OBI (no rebuild required) or Orchestrion (check its `go.mod` for minimum version) are the options.
 
-Go 1.25 isn't ancient — at time of writing it's current — but in environments with slow upgrade cycles or pinned toolchains, this will be the first question to answer.
+Go 1.25 isn't ancient. At time of writing it is current, but in environments with slow upgrade cycles or pinned toolchains, this will be the first question to answer.
 
-### Why two tools
+## Why two tools
 
 It's a fair question. The OTel SIG blog post describes it as Datadog and Alibaba having "independently built compile-time Go instrumentation tools and converged." Orchestrion is Datadog's production-tested tool with broad dd-trace-go integration. The SIG decided the right move was to build a new OTel-native tool from scratch rather than donate Orchestrion wholesale, keeping Orchestrion as Datadog's supported product while the SIG owns the OTel-standard version.
 
@@ -67,19 +76,19 @@ The practical implication for users: if you're on the OTel SDK and want vendor-n
 
 The mechanism is identical. Choosing between them is mostly about which tracer SDK you're committing to.
 
-### What it instruments
+## What it instruments
 
 The OTel blog describes otelc as instrumenting "your code, its dependencies, and the standard library." The exact list of supported frameworks for v1.0.1 is in the repository's instrumentation packages. The Orchestrion + dd-trace-go side (which otelc is converging toward) covers HTTP frameworks (net/http, gin, gorilla/mux, chi, echo, fiber), gRPC, database/sql and ORM layers (sqlx, gorm, mongo-driver), Redis (go-redis v6-v9, redigo, rueidis), Kafka, AWS SDK v1/v2, and Kubernetes client-go.
 
 otelc's coverage is growing toward parity. Check the repo's current state for the exact list — it will have changed between when this was written and when you read it.
 
-### Where it fits relative to OBI
+## Where it fits relative to OBI
 
-OBI and otelc address the same underlying problem — zero source code changes — but from opposite ends.
+OBI and otelc address the same underlying problem, zero source code changes, from opposite ends.
 
 OBI attaches from outside the process at runtime. It requires no rebuild, works immediately on deployed services, and handles multiple languages from a single DaemonSet. But it's bounded by what eBPF can observe at library boundaries: RED metrics and library-level spans for the 13 Go libraries it supports. It cannot generate custom spans or instrument business logic.
 
-otelc works at build time. It requires a rebuild and Go 1.25+. In exchange, it can instrument anything: stdlib internals, your own functions, dependencies, business logic. The injected spans have the same fidelity as manually written OTel SDK calls, because after the AST rewrite, they are manually written OTel SDK calls — the compiler just doesn't know you didn't type them.
+otelc works at build time. It requires a rebuild and Go 1.25+. In exchange, it can instrument anything: stdlib internals, your own functions, dependencies, business logic. The injected spans have the same fidelity as manually written OTel SDK calls, because after the AST rewrite, they are manually written OTel SDK calls. The compiler just doesn't know you didn't type them.
 
 The decision rule I use:
 

--- a/content/posts/otelc-compile-time-go-traces.md
+++ b/content/posts/otelc-compile-time-go-traces.md
@@ -12,8 +12,7 @@ tags:
   - observability
   - opentelemetry
   - compile-time-instrumentation
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---
@@ -98,4 +97,4 @@ The decision rule I use:
 
 For GopherCon UK 2026, otelc landing at v1.0.1 two weeks before the conference is the most timely piece of the story. The first stable release of an OTel-native compile-time Go instrumentation tool is a meaningful moment in the "Go without a single line of code" narrative, even if "without a single line" really means "with one build command substitution and Go 1.25 on your toolchain."
 
-The `-toolexec` mechanism is one of Go's least-discussed build features. It was designed for code coverage and cgo toolchains — the Go team did not plan it as an instrumentation API. It turns out to be exactly the right hook for compile-time AOP anyway.
+The `-toolexec` mechanism is one of Go's least-discussed build features. Its documented purpose is generic: a program to invoke toolchain steps like `vet` and `asm` through, useful for cross-compile wrappers, emulators, and tools like garble. The Go team did not plan it as an instrumentation API. It turns out to be exactly the right hook for compile-time AOP anyway.

--- a/content/posts/why-go-cant-be-monkey-patched.md
+++ b/content/posts/why-go-cant-be-monkey-patched.md
@@ -1,8 +1,8 @@
 ---
 title: "Why Go can't be monkey-patched (and what people do about it)"
 description: "Go is structurally hostile to zero-touch instrumentation, from the missing classloader to a goroutine-local storage hack that patches the runtime at compile time."
-date: 2026-07-28T00:00:00Z
-publishDate: 2026-07-28T00:00:00Z
+date: 2026-09-01T00:00:00Z
+publishDate: 2026-09-01T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/why-go-cant-be-monkey-patched.md
+++ b/content/posts/why-go-cant-be-monkey-patched.md
@@ -13,8 +13,7 @@ tags:
   - opentelemetry
   - ebpf
   - compile-time-instrumentation
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---
@@ -29,7 +28,7 @@ That matters because it closes off the standard instrumentation escape hatches:
 
 - No bytecode means you can't rewrite classes at load time. Java agents work because the JVM can intercept `ClassLoader.defineClass` and transform bytecodes before they execute. Go has no equivalent: the compiler runs on your machine, not on the server.
 - No classloader means there's no intercept point between "file on disk" and "code executing."
-- Go links statically by default. The `LD_PRELOAD` trick, the classic Linux mechanism for injecting a shared library into any process, requires the dynamic linker to run, and Go's internal linker doesn't invoke it. To use `LD_PRELOAD` with a Go binary, you have to force external linking with `-linkmode=external`. That's not a supported feature; it's a workaround with its own sharp edges. Dynatrace's OneAgent documentation says outright: static Go binaries with cgo are unsupported.
+- Go links statically by default. The `LD_PRELOAD` trick, the classic Linux mechanism for injecting a shared library into any process, requires the dynamic linker to run, and Go's internal linker doesn't invoke it. To use `LD_PRELOAD` with a Go binary, you have to force external linking with `-linkmode=external`. That's not a supported feature; it's a workaround with its own sharp edges. Dynatrace's OneAgent documentation is explicit about this, and the wording trips people up: it's static Go binaries *built with cgo* that are unsupported, because they still carry a static dependency on libc that can conflict with the one OneAgent injects. Pure static binaries (`CGO_ENABLED=0`, no cgo at all) are fine.
 - Go exposes no general runtime hook API. Go has an internal `exithook` mechanism, but it is scoped strictly to program termination, not a general interception surface.
 
 What about `go:linkname`? It lets packages access unexported runtime symbols, and you'll find it used in tracers. But the Go runtime source contains this comment in `proc.go`:
@@ -89,7 +88,7 @@ getg().__dd_gls_v2 = nil
 
 The consumer side in dd-trace-go checks whether Orchestrion is present at init time and falls back to a no-op if it isn't.
 
-This is genuinely impressive engineering. It's also a sign of how desperate things are: you're patching the Go runtime struct layout at compile time, using `go:linkname` for variable aliasing (which broke between Go 1.22 and 1.23, tracked in golang/go#72032), and relying on a YAML file that references the Go team's own `HACKING.md`. The Go team considers this access pattern deeply unofficial.
+This is genuinely impressive engineering. It's also a sign of how desperate things are: you're patching the Go runtime struct layout at compile time, using `go:linkname` for variable aliasing (which broke between Go 1.22 and 1.23, tracked in golang/go#72032 — a side effect of the broader linkname lockdown in golang/go#67401), and relying on a YAML file that references the Go team's own `HACKING.md`. The Go team considers this access pattern deeply unofficial.
 
 Every other major runtime has a designed hook point for this kind of thing. Thread-local storage in Java, `contextvars` in Python, `AsyncLocalStorage` in Node.js. Go's goroutine-local storage solution is: patch the runtime struct and hope the linker's symbol resolution stays stable.
 

--- a/content/posts/why-go-cant-be-monkey-patched.md
+++ b/content/posts/why-go-cant-be-monkey-patched.md
@@ -1,50 +1,60 @@
 ---
 title: "Why Go can't be monkey-patched (and what people do about it)"
-date: 2026-07-28
+description: "Go is structurally hostile to zero-touch instrumentation, from the missing classloader to a goroutine-local storage hack that patches the runtime at compile time."
+date: 2026-07-28T00:00:00Z
+publishDate: 2026-07-28T00:00:00Z
 draft: true
-description: "Go is structurally hostile to zero-touch instrumentation. Here's why — from the missing classloader to a goroutine-local storage hack that patches the Go runtime at compile time."
-tags: ["go", "observability", "opentelemetry", "ebpf", "compile-time-instrumentation"]
-categories: ["engineering"]
-slug: "why-go-cant-be-monkey-patched"
-toc: true
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - ebpf
+  - compile-time-instrumentation
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
-If you've spent time on Java or Python instrumentation, the zero-touch story is obvious: intercept the bytecode at load time, or swap out a method at runtime, or use an agent that the JVM already knows how to host. Go has none of that. This isn't a gap waiting to be filled — it's a consequence of how Go was designed.
+If you've spent time on Java or Python instrumentation, the zero-touch story is obvious: intercept the bytecode at load time, or swap out a method at runtime, or use an agent that the JVM already knows how to host. Go has none of that. This is not a gap waiting to be filled. It is a consequence of how Go was designed.
 
-### The structural problem
+## The structural problem
 
-Go compiles to native machine code. When you run `go build`, you get a self-contained binary. There is no bytecode layer, no classloader, no intermediate representation sitting between your code and the CPU.
+Go compiles to native machine code. When you run `go build`, you get a self-contained binary. You get no bytecode layer, no classloader, and no intermediate representation sitting between your code and the CPU.
 
 That matters because it closes off the standard instrumentation escape hatches:
 
-- No bytecode means you can't rewrite classes at load time. Java agents work because the JVM can intercept `ClassLoader.defineClass` and transform bytecodes before they execute. Go has no equivalent — the compiler runs on your machine, not on the server.
+- No bytecode means you can't rewrite classes at load time. Java agents work because the JVM can intercept `ClassLoader.defineClass` and transform bytecodes before they execute. Go has no equivalent: the compiler runs on your machine, not on the server.
 - No classloader means there's no intercept point between "file on disk" and "code executing."
-- Go links statically by default. The `LD_PRELOAD` trick — the classic Linux mechanism for injecting a shared library into any process — requires the dynamic linker to run, and Go's internal linker doesn't invoke it. To use `LD_PRELOAD` with a Go binary, you have to force external linking with `-linkmode=external`. That's not a supported feature; it's a workaround with its own sharp edges. Dynatrace's OneAgent documentation says outright: static Go binaries with cgo are unsupported.
-- There is no general runtime hook API. Go has an internal `exithook` mechanism, but it's scoped strictly to program termination — it's not a general interception surface.
+- Go links statically by default. The `LD_PRELOAD` trick, the classic Linux mechanism for injecting a shared library into any process, requires the dynamic linker to run, and Go's internal linker doesn't invoke it. To use `LD_PRELOAD` with a Go binary, you have to force external linking with `-linkmode=external`. That's not a supported feature; it's a workaround with its own sharp edges. Dynatrace's OneAgent documentation says outright: static Go binaries with cgo are unsupported.
+- Go exposes no general runtime hook API. Go has an internal `exithook` mechanism, but it is scoped strictly to program termination, not a general interception surface.
 
 What about `go:linkname`? It lets packages access unexported runtime symbols, and you'll find it used in tracers. But the Go runtime source contains this comment in `proc.go`:
 
 > "gopark should be an internal detail, but widely used packages access it using linkname. Notable members of the hall of shame include…"
 
-The Go team added those stubs reluctantly, because enough widely-used packages had already started abusing them. That's not a hook point — it's a "we can't remove this without breaking half the ecosystem" accommodation.
+The Go team added those stubs reluctantly, because enough widely-used packages had already started abusing them. That is not a hook point. It is a "we can't remove this without breaking widely used packages" accommodation.
 
-### What people actually do
+## What people actually do
 
 Given that the normal approaches don't work, three different strategies have emerged.
 
-**eBPF from the outside.** Linux's eBPF subsystem can attach probes to function entry and exit points in any running binary without modifying it. You don't need to change the Go binary at all — you attach from a privileged sidecar. The constraint is that you're limited to what's observable at function boundaries: arguments, return values, call counts. You can't see inside a function, and you need Linux 5.8+ with BTF enabled.
+**eBPF from the outside.** Linux's eBPF subsystem can attach probes to function entry and exit points in any running binary without modifying it. You don't need to change the Go binary at all. You attach from a privileged sidecar. The constraint is that you're limited to what's observable at function boundaries: arguments, return values, call counts. You can't see inside a function, and you need Linux 5.8+ with BTF enabled.
 
 **Compile-time AST rewriting.** Instead of intercepting at runtime, intercept the build. Go's `-toolexec` flag lets you replace the `go tool compile` invocation with your own wrapper. That wrapper parses each source file into a syntax tree, injects instrumentation code, and hands the modified source to the real compiler. From the compiler's perspective, you just wrote the instrumentation yourself. No runtime overhead from the mechanism, no kernel privileges, but you need to rebuild.
 
 **Runtime injection with caveats.** Some vendors use binary trampolines or shared-library injection on Go binaries built with external linking. This works in narrow conditions and fails in others. For binaries built with `CGO_ENABLED=0`, it typically doesn't work at all.
 
-Of these, compile-time rewriting is currently the most broadly production-ready. It works across Go versions, requires no kernel support, and can instrument arbitrary code — not just network calls.
+Of these, compile-time rewriting is currently the most broadly production-ready. It works across Go versions, requires no kernel support, and can instrument network calls and arbitrary code.
 
-### The goroutine problem nobody talks about
+## The goroutine problem nobody talks about
 
 Even compile-time approaches hit a wall that exposes how deep Go's structural hostility goes. Consider distributed tracing: you need to propagate a trace context across goroutines. But Go has no goroutine-local storage. By design. If you write `go func() { ... }()`, there's no built-in way to inherit the parent's trace context.
 
-The way DataDog's compile-time tool, Orchestrion, solves this is striking. It injects a synthetic field directly into the Go runtime's internal `g` struct — the struct that represents each goroutine:
+The way Datadog's compile-time tool, Orchestrion, solves this is striking. It injects a synthetic field directly into the Go runtime's internal `g` struct, the struct that represents each goroutine:
 
 ```yaml
 # internal/orchestrion/gls.orchestrion.yml
@@ -83,12 +93,12 @@ This is genuinely impressive engineering. It's also a sign of how desperate thin
 
 Every other major runtime has a designed hook point for this kind of thing. Thread-local storage in Java, `contextvars` in Python, `AsyncLocalStorage` in Node.js. Go's goroutine-local storage solution is: patch the runtime struct and hope the linker's symbol resolution stays stable.
 
-### The landscape today
+## The three workarounds people ship today
 
 For GopherCon UK 2026, I'm covering three tools that take these approaches seriously:
 
 - **OBI** (OpenTelemetry eBPF Instrumentation, formerly Grafana Beyla) — the eBPF path, zero rebuild required.
 - **otelc** (OTel SIG compile-time instrumentation) — the `-toolexec` path, requires Go 1.25+.
-- **Orchestrion** (DataDog) — the same mechanism as otelc, battle-tested, includes the GLS hack above.
+- **Orchestrion** (Datadog) — the same mechanism as otelc, battle-tested, includes the GLS hack above.
 
 None of them is a clean solution. They're all workarounds for a runtime that was built for simplicity rather than observability. But they work, and they're worth understanding.

--- a/content/posts/why-go-cant-be-monkey-patched.md
+++ b/content/posts/why-go-cant-be-monkey-patched.md
@@ -1,0 +1,94 @@
+---
+title: "Why Go can't be monkey-patched (and what people do about it)"
+date: 2026-07-28
+draft: true
+description: "Go is structurally hostile to zero-touch instrumentation. Here's why — from the missing classloader to a goroutine-local storage hack that patches the Go runtime at compile time."
+tags: ["go", "observability", "opentelemetry", "ebpf", "compile-time-instrumentation"]
+categories: ["engineering"]
+slug: "why-go-cant-be-monkey-patched"
+toc: true
+---
+
+If you've spent time on Java or Python instrumentation, the zero-touch story is obvious: intercept the bytecode at load time, or swap out a method at runtime, or use an agent that the JVM already knows how to host. Go has none of that. This isn't a gap waiting to be filled — it's a consequence of how Go was designed.
+
+### The structural problem
+
+Go compiles to native machine code. When you run `go build`, you get a self-contained binary. There is no bytecode layer, no classloader, no intermediate representation sitting between your code and the CPU.
+
+That matters because it closes off the standard instrumentation escape hatches:
+
+- No bytecode means you can't rewrite classes at load time. Java agents work because the JVM can intercept `ClassLoader.defineClass` and transform bytecodes before they execute. Go has no equivalent — the compiler runs on your machine, not on the server.
+- No classloader means there's no intercept point between "file on disk" and "code executing."
+- Go links statically by default. The `LD_PRELOAD` trick — the classic Linux mechanism for injecting a shared library into any process — requires the dynamic linker to run, and Go's internal linker doesn't invoke it. To use `LD_PRELOAD` with a Go binary, you have to force external linking with `-linkmode=external`. That's not a supported feature; it's a workaround with its own sharp edges. Dynatrace's OneAgent documentation says outright: static Go binaries with cgo are unsupported.
+- There is no general runtime hook API. Go has an internal `exithook` mechanism, but it's scoped strictly to program termination — it's not a general interception surface.
+
+What about `go:linkname`? It lets packages access unexported runtime symbols, and you'll find it used in tracers. But the Go runtime source contains this comment in `proc.go`:
+
+> "gopark should be an internal detail, but widely used packages access it using linkname. Notable members of the hall of shame include…"
+
+The Go team added those stubs reluctantly, because enough widely-used packages had already started abusing them. That's not a hook point — it's a "we can't remove this without breaking half the ecosystem" accommodation.
+
+### What people actually do
+
+Given that the normal approaches don't work, three different strategies have emerged.
+
+**eBPF from the outside.** Linux's eBPF subsystem can attach probes to function entry and exit points in any running binary without modifying it. You don't need to change the Go binary at all — you attach from a privileged sidecar. The constraint is that you're limited to what's observable at function boundaries: arguments, return values, call counts. You can't see inside a function, and you need Linux 5.8+ with BTF enabled.
+
+**Compile-time AST rewriting.** Instead of intercepting at runtime, intercept the build. Go's `-toolexec` flag lets you replace the `go tool compile` invocation with your own wrapper. That wrapper parses each source file into a syntax tree, injects instrumentation code, and hands the modified source to the real compiler. From the compiler's perspective, you just wrote the instrumentation yourself. No runtime overhead from the mechanism, no kernel privileges, but you need to rebuild.
+
+**Runtime injection with caveats.** Some vendors use binary trampolines or shared-library injection on Go binaries built with external linking. This works in narrow conditions and fails in others. For binaries built with `CGO_ENABLED=0`, it typically doesn't work at all.
+
+Of these, compile-time rewriting is currently the most broadly production-ready. It works across Go versions, requires no kernel support, and can instrument arbitrary code — not just network calls.
+
+### The goroutine problem nobody talks about
+
+Even compile-time approaches hit a wall that exposes how deep Go's structural hostility goes. Consider distributed tracing: you need to propagate a trace context across goroutines. But Go has no goroutine-local storage. By design. If you write `go func() { ... }()`, there's no built-in way to inherit the parent's trace context.
+
+The way DataDog's compile-time tool, Orchestrion, solves this is striking. It injects a synthetic field directly into the Go runtime's internal `g` struct — the struct that represents each goroutine:
+
+```yaml
+# internal/orchestrion/gls.orchestrion.yml
+join-point:
+  struct-definition: runtime.g
+advice:
+  - add-struct-field:
+      name: __dd_gls_v2
+      type: any
+```
+
+This YAML aspect tells the compiler to add `__dd_gls_v2 any` to `runtime.g`. Every goroutine gets a copy. Then Orchestrion injects `go:linkname` functions to get and set that field:
+
+```go
+//go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get.V2
+var __dd_orchestrion_gls_get = func() any {
+    return getg().m.curg.__dd_gls_v2
+}
+
+//go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set.V2
+var __dd_orchestrion_gls_set = func(val any) {
+    getg().m.curg.__dd_gls_v2 = val
+}
+```
+
+And to prevent memory leaks, a cleanup hook into `goexit1`:
+
+```go
+// Injected into runtime.goexit1:
+getg().__dd_gls_v2 = nil
+```
+
+The consumer side in dd-trace-go checks whether Orchestrion is present at init time and falls back to a no-op if it isn't.
+
+This is genuinely impressive engineering. It's also a sign of how desperate things are: you're patching the Go runtime struct layout at compile time, using `go:linkname` for variable aliasing (which broke between Go 1.22 and 1.23, tracked in golang/go#72032), and relying on a YAML file that references the Go team's own `HACKING.md`. The Go team considers this access pattern deeply unofficial.
+
+Every other major runtime has a designed hook point for this kind of thing. Thread-local storage in Java, `contextvars` in Python, `AsyncLocalStorage` in Node.js. Go's goroutine-local storage solution is: patch the runtime struct and hope the linker's symbol resolution stays stable.
+
+### The landscape today
+
+For GopherCon UK 2026, I'm covering three tools that take these approaches seriously:
+
+- **OBI** (OpenTelemetry eBPF Instrumentation, formerly Grafana Beyla) — the eBPF path, zero rebuild required.
+- **otelc** (OTel SIG compile-time instrumentation) — the `-toolexec` path, requires Go 1.25+.
+- **Orchestrion** (DataDog) — the same mechanism as otelc, battle-tested, includes the GLS hack above.
+
+None of them is a clean solution. They're all workarounds for a runtime that was built for simplicity rather than observability. But they work, and they're worth understanding.

--- a/content/posts/why-go-cant-be-monkey-patched.md
+++ b/content/posts/why-go-cant-be-monkey-patched.md
@@ -1,8 +1,8 @@
 ---
 title: "Why Go can't be monkey-patched (and what people do about it)"
 description: "Go is structurally hostile to zero-touch instrumentation, from the missing classloader to a goroutine-local storage hack that patches the runtime at compile time."
-date: 2026-09-01T00:00:00Z
-publishDate: 2026-09-01T00:00:00Z
+date: 2026-10-02T00:00:00Z
+publishDate: 2026-10-02T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -1,28 +1,42 @@
 ---
 title: "Making zero-touch Go observability agent-actionable"
-date: 2026-07-29
+description: "Turn the OBI vs. otelc decision into an agent-readable runbook, then make the Kubernetes path boring enough to run with one command."
+date: 2026-08-03T00:00:00Z
+publishDate: 2026-08-03T00:00:00Z
 draft: true
-tags: ["go", "observability", "opentelemetry", "ebpf", "ai", "tooling"]
-slug: zero-touch-go-observability-agent-actionable
+categories:
+  - engineering
+tags:
+  - blog
+  - go
+  - observability
+  - opentelemetry
+  - ebpf
+  - ai
+  - tooling
+series:
+  - How to Instrument Go Without Changing a Single Line of Code
+showToc: true
+tocOpen: false
 ---
 
-The decision of how to instrument a Go service isn't complicated, but it is context-dependent. Two tools cover most cases — OBI for production runtime attach, otelc for local dev compile-time instrumentation — and choosing between them comes down to a handful of concrete questions: Is the service already deployed? Can you rebuild? Do you need custom spans or just HTTP/gRPC RED metrics?
+A useful agent skill starts with a boring question: is this Go service already running, or can I rebuild it?
 
-That decision tree is simple enough to encode. And if it's encodable, it's automatable.
+If it is already running in Kubernetes, OBI is the default. If I can rebuild locally and need function-level spans, otelc is the default. The rest of the decision tree is mostly checking privileges, Go version, collector endpoint, and whether RED metrics are enough.
 
-### The routing logic
+## The routing logic
 
 The core decision looks like this:
 
 **Use OBI** when:
 - The service is already running (production, staging, Kubernetes, Docker Compose)
 - Rebuilding or redeploying isn't acceptable
-- The fleet is polyglot — multiple languages, one instrumentation layer
+- The fleet is polyglot: more than one language, one instrumentation layer
 - You need HTTP/gRPC RED metrics (rate, errors, duration) or library-level spans
 
 **Use otelc** when:
 - You're working locally or in a dev environment where you control the build
-- You need granular spans — specific functions, business logic, custom code paths
+- You need granular spans for specific functions, business logic, or custom code paths
 - You want to trace a specific slow path with exact data
 - You're willing to rebuild with `otelc go build`
 
@@ -30,9 +44,9 @@ If neither fits cleanly, the tiebreaker question is: *"Is this for a running pro
 
 Both paths require an OTel Collector or Jaeger to receive the output. OBI additionally needs Linux kernel 5.8+ with BTF and six capabilities (`CAP_BPF`, `CAP_SYS_PTRACE`, `CAP_NET_RAW`, `CAP_CHECKPOINT_RESTORE`, `CAP_DAC_READ_SEARCH`, `CAP_PERFMON`). otelc needs the service to be in a language version it supports and a dev machine where you can run `go build`.
 
-### What OBI actually covers
+## What OBI actually covers
 
-OBI instruments 13 Go libraries out of the box: `net/http`, gin, gRPC, gorilla/mux, go-redis, Kafka, `database/sql`, and others. It attaches from outside the process — no LD_PRELOAD, no restart, no rebuild. For Kubernetes, one DaemonSet covers every pod on every node:
+OBI instruments 13 Go libraries out of the box: `net/http`, gin, gRPC, gorilla/mux, go-redis, Kafka, `database/sql`, and others. It attaches from outside the process: no LD_PRELOAD, no restart, no rebuild. For Kubernetes, one DaemonSet covers every pod on every node:
 
 ```bash
 kubectl apply -f https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.10.0/obi-daemonset.yaml
@@ -53,9 +67,9 @@ obi:
     - /sys/kernel/debug:/sys/kernel/debug
 ```
 
-The limitation is real and worth stating: custom spans, SQL query details, business-logic events — anything that isn't at the HTTP/gRPC boundary — still needs code changes. OBI observes what crosses library boundaries. It can't see inside your application logic.
+The span-depth cost is concrete: custom spans, SQL query details, and business-logic events still need code changes when they are not at the HTTP/gRPC boundary. OBI observes what crosses library boundaries. It can't see inside your application logic.
 
-### What otelc covers
+## What otelc covers
 
 otelc takes the compile-time path: `otelc go build` is a drop-in for `go build`. It instruments your code, its dependencies, and parts of the standard library at the AST level. The injected spans have the same cost as manually written OTel code.
 
@@ -78,15 +92,15 @@ docker run -d --name jaeger \
 
 The tradeoff is build-time coupling. You can't attach otelc to a running production binary. It's the right tool when you're chasing down a specific slow code path and need exact function-level data, not when you're trying to instrument a fleet without touching running services.
 
-### Making the decision executable
+## Making the decision executable
 
-The routing logic above lives in a Claude Code skill called `collect-go-telemetry`. The skill encodes exactly the decision tree described here — production vs. dev, polyglot vs. Go-only, RED metrics vs. granular spans — and then pulls only the integration docs relevant to the libraries the service actually uses.
+The routing logic above lives in a Claude Code skill called `collect-go-telemetry`. The skill encodes the decision tree described here: production vs. dev, polyglot vs. Go-only, RED metrics vs. granular spans. Then it pulls only the integration docs relevant to the libraries the service actually uses.
 
 The last part matters for a practical reason: OBI's support matrix and otelc's aspect catalog are large. Fetching the full catalogs for every instrumentation request is wasteful. The skill uses per-library fetch scripts (`obi-integration.sh <library>`, `otelc-aspect.sh <import-path>`) to retrieve only the relevant sections. This is a pattern worth copying: treat your documentation as a retrieval problem, not a context-stuffing problem.
 
-The skill's existence is the point. Observability decisions that engineers document in runbooks — "for production services use OBI, for local dev use otelc, here's how to set up each" — can be encoded as agent-actionable tools. The decision tree doesn't change per-request; what changes is the context (which service, which libraries, which environment). An agent can evaluate that context and execute the right steps.
+The useful part is the named checklist. A runbook can say: "for production services use OBI, for local dev use otelc, here's how to set up each." The decision tree doesn't change per request; the context does: which service, which libraries, which environment. An agent can inspect that context and execute the right steps.
 
-### kubectl-obi: one command to instrument a cluster
+## kubectl-obi: one command to instrument a cluster
 
 For the Kubernetes path specifically, `kubectl-obi` is a krew plugin that wraps the DaemonSet lifecycle:
 
@@ -106,12 +120,10 @@ kubectl obi detach
 
 The plugin handles the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually. `kubectl obi attach` is the zero-argument case that does the right thing for most clusters.
 
-The current implementation is a skeleton — the flag parsing and command structure are complete, the actual Kubernetes API calls are wired up but need a cluster to finish validating. The interface design is the point: zero-touch instrumentation should be a single verb, not a multi-step YAML exercise.
+The current implementation is a skeleton. The flag parsing and command structure are complete, and the actual Kubernetes API calls are wired up but need a cluster to finish validating. The interface design is the point: zero-touch instrumentation should be a single verb, not a multi-step YAML exercise.
 
-### The principle
+## What I would automate next
 
-The best observability is the kind your tools can set up for you.
+The useful part is not that an agent can memorize two tools. The useful part is that the messy operational checks have names: kernel version, capabilities, collector endpoint, rebuild access, Go version, and span depth.
 
-This isn't about replacing engineering judgment. The decision tree still requires understanding what OBI can and can't observe, what privileges eBPF needs, what otelc's build requirements are. But once that judgment is encoded — once the routing logic is written down and the commands are documented — there's no reason a human has to re-execute it from memory every time. That's exactly the kind of procedural work that agents are good at.
-
-The `collect-go-telemetry` skill and `kubectl-obi` are small examples of a broader pattern: take the decision framework from a talk or a runbook, make it executable, and let your tooling do the legwork.
+I still would not let a skill silently attach eBPF to production. The next version should produce a plan first: what it will attach, what privileges it needs, and how to roll it back. Boring, reversible, logged. Observability needs more of that kind of magic trick.

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -1,0 +1,117 @@
+---
+title: "Making zero-touch Go observability agent-actionable"
+date: 2026-07-29
+draft: true
+tags: ["go", "observability", "opentelemetry", "ebpf", "ai", "tooling"]
+slug: zero-touch-go-observability-agent-actionable
+---
+
+The decision of how to instrument a Go service isn't complicated, but it is context-dependent. Two tools cover most cases — OBI for production runtime attach, otelc for local dev compile-time instrumentation — and choosing between them comes down to a handful of concrete questions: Is the service already deployed? Can you rebuild? Do you need custom spans or just HTTP/gRPC RED metrics?
+
+That decision tree is simple enough to encode. And if it's encodable, it's automatable.
+
+### The routing logic
+
+The core decision looks like this:
+
+**Use OBI** when:
+- The service is already running (production, staging, Kubernetes, Docker Compose)
+- Rebuilding or redeploying isn't acceptable
+- The fleet is polyglot — multiple languages, one instrumentation layer
+- You need HTTP/gRPC RED metrics (rate, errors, duration) or library-level spans
+
+**Use otelc** when:
+- You're working locally or in a dev environment where you control the build
+- You need granular spans — specific functions, business logic, custom code paths
+- You want to trace a specific slow path with exact data
+- You're willing to rebuild with `otelc go build`
+
+If neither fits cleanly, the tiebreaker question is: *"Is this for a running production service (OBI) or local development where you can rebuild (otelc)?"*
+
+Both paths require an OTel Collector or Jaeger to receive the output. OBI additionally needs Linux kernel 5.8+ with BTF and six capabilities (`CAP_BPF`, `CAP_SYS_PTRACE`, `CAP_NET_RAW`, `CAP_CHECKPOINT_RESTORE`, `CAP_DAC_READ_SEARCH`, `CAP_PERFMON`). otelc needs the service to be in a language version it supports and a dev machine where you can run `go build`.
+
+### What OBI actually covers
+
+OBI instruments 13 Go libraries out of the box: `net/http`, gin, gRPC, gorilla/mux, go-redis, Kafka, `database/sql`, and others. It attaches from outside the process — no LD_PRELOAD, no restart, no rebuild. For Kubernetes, one DaemonSet covers every pod on every node:
+
+```bash
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.10.0/obi-daemonset.yaml
+kubectl get pods -n obi-system
+```
+
+For Docker Compose, add an OBI container alongside your service:
+
+```yaml
+obi:
+  image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation:v0.10.0
+  pid: host
+  privileged: true
+  environment:
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+  volumes:
+    - /sys/fs/bpf:/sys/fs/bpf
+    - /sys/kernel/debug:/sys/kernel/debug
+```
+
+The limitation is real and worth stating: custom spans, SQL query details, business-logic events — anything that isn't at the HTTP/gRPC boundary — still needs code changes. OBI observes what crosses library boundaries. It can't see inside your application logic.
+
+### What otelc covers
+
+otelc takes the compile-time path: `otelc go build` is a drop-in for `go build`. It instruments your code, its dependencies, and parts of the standard library at the AST level. The injected spans have the same cost as manually written OTel code.
+
+```bash
+go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
+otelc go build -o ./myapp ./...
+
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_SERVICE_NAME=my-go-service \
+./myapp
+```
+
+For local dev, pair this with Jaeger all-in-one:
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+```
+
+The tradeoff is build-time coupling. You can't attach otelc to a running production binary. It's the right tool when you're chasing down a specific slow code path and need exact function-level data, not when you're trying to instrument a fleet without touching running services.
+
+### Making the decision executable
+
+The routing logic above lives in a Claude Code skill called `collect-go-telemetry`. The skill encodes exactly the decision tree described here — production vs. dev, polyglot vs. Go-only, RED metrics vs. granular spans — and then pulls only the integration docs relevant to the libraries the service actually uses.
+
+The last part matters for a practical reason: OBI's support matrix and otelc's aspect catalog are large. Fetching the full catalogs for every instrumentation request is wasteful. The skill uses per-library fetch scripts (`obi-integration.sh <library>`, `otelc-aspect.sh <import-path>`) to retrieve only the relevant sections. This is a pattern worth copying: treat your documentation as a retrieval problem, not a context-stuffing problem.
+
+The skill's existence is the point. Observability decisions that engineers document in runbooks — "for production services use OBI, for local dev use otelc, here's how to set up each" — can be encoded as agent-actionable tools. The decision tree doesn't change per-request; what changes is the context (which service, which libraries, which environment). An agent can evaluate that context and execute the right steps.
+
+### kubectl-obi: one command to instrument a cluster
+
+For the Kubernetes path specifically, `kubectl-obi` is a krew plugin that wraps the DaemonSet lifecycle:
+
+```bash
+# Instrument everything on every node
+kubectl obi attach
+
+# Check what's being instrumented
+kubectl obi status --all-namespaces
+
+# Target one deployment with a sidecar instead
+kubectl obi attach my-service --mode=sidecar --namespace=production
+
+# Stop instrumenting
+kubectl obi detach
+```
+
+The plugin handles the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually. `kubectl obi attach` is the zero-argument case that does the right thing for most clusters.
+
+The current implementation is a skeleton — the flag parsing and command structure are complete, the actual Kubernetes API calls are wired up but need a cluster to finish validating. The interface design is the point: zero-touch instrumentation should be a single verb, not a multi-step YAML exercise.
+
+### The principle
+
+The best observability is the kind your tools can set up for you.
+
+This isn't about replacing engineering judgment. The decision tree still requires understanding what OBI can and can't observe, what privileges eBPF needs, what otelc's build requirements are. But once that judgment is encoded — once the routing logic is written down and the commands are documented — there's no reason a human has to re-execute it from memory every time. That's exactly the kind of procedural work that agents are good at.
+
+The `collect-go-telemetry` skill and `kubectl-obi` are small examples of a broader pattern: take the decision framework from a talk or a runbook, make it executable, and let your tooling do the legwork.

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -45,18 +45,19 @@ Both paths require an OTel Collector or Jaeger to receive the output. OBI additi
 
 ## What OBI actually covers
 
-OBI instruments 13 Go libraries out of the box: `net/http`, gin, gRPC, gorilla/mux, go-redis, Kafka, `database/sql`, and others. It attaches from outside the process: no LD_PRELOAD, no restart, no rebuild. For Kubernetes, one DaemonSet covers every pod on every node:
+OBI instruments 13 Go libraries out of the box: `net/http`, gin, gRPC, gorilla/mux, go-redis, Kafka, `database/sql`, and others. It attaches from outside the process: no LD_PRELOAD, no restart, no rebuild. For Kubernetes, the Helm chart installs the DaemonSet path:
 
 ```bash
-kubectl apply -f https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v0.10.0/obi-daemonset.yaml
-kubectl get pods -n obi-system
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm install obi -n obi --create-namespace open-telemetry/opentelemetry-ebpf-instrumentation
+kubectl get pods -n obi
 ```
 
 For Docker Compose, add an OBI container alongside your service:
 
 ```yaml
 obi:
-  image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation:v0.10.0
+  image: otel/ebpf-instrument:v0.10.0
   pid: host
   privileged: true
   environment:
@@ -117,7 +118,7 @@ kubectl obi attach my-service --mode=sidecar --namespace=production
 kubectl obi detach
 ```
 
-The plugin is meant to handle the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually, with `kubectl obi attach` as the zero-argument case that does the right thing for most clusters.
+The plugin is meant to handle the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually. `kubectl obi` becomes the zero-memorization path: attach a target, inspect status, detach, and never paste a release URL from memory.
 
 The current implementation is a skeleton: flag parsing and command structure are done, the Kubernetes API calls are wired up but unvalidated against a real cluster, and it isn't released anywhere yet. I'll link the source here once it's public.
 

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -1,8 +1,8 @@
 ---
 title: "Making zero-touch Go observability agent-actionable"
 description: "Turn the OBI vs. otelc decision into an agent-readable runbook, then make the Kubernetes path boring enough to run with one command."
-date: 2026-10-06T00:00:00Z
-publishDate: 2026-10-06T00:00:00Z
+date: 2026-11-06T00:00:00Z
+publishDate: 2026-11-06T00:00:00Z
 draft: true
 categories:
   - engineering

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -14,8 +14,7 @@ tags:
   - ebpf
   - ai
   - tooling
-series:
-  - How to Instrument Go Without Changing a Single Line of Code
+series: "How to Instrument Go Without Changing a Single Line of Code"
 showToc: true
 tocOpen: false
 ---
@@ -102,7 +101,7 @@ The useful part is the named checklist. A runbook can say: "for production servi
 
 ## kubectl-obi: one command to instrument a cluster
 
-For the Kubernetes path specifically, `kubectl-obi` is a krew plugin that wraps the DaemonSet lifecycle:
+For the Kubernetes path specifically, I'm building `kubectl-obi` for this talk: a `kubectl` plugin, in the krew style, that wraps the DaemonSet lifecycle so zero-touch instrumentation is a single verb instead of a multi-step YAML exercise. It is not published to the krew index and there's no public source yet — treat what follows as the interface design, not a tool you can install today:
 
 ```bash
 # Instrument everything on every node
@@ -118,9 +117,9 @@ kubectl obi attach my-service --mode=sidecar --namespace=production
 kubectl obi detach
 ```
 
-The plugin handles the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually. `kubectl obi attach` is the zero-argument case that does the right thing for most clusters.
+The plugin is meant to handle the DaemonSet apply/delete without requiring you to remember the manifest URL or manage YAML manually, with `kubectl obi attach` as the zero-argument case that does the right thing for most clusters.
 
-The current implementation is a skeleton. The flag parsing and command structure are complete, and the actual Kubernetes API calls are wired up but need a cluster to finish validating. The interface design is the point: zero-touch instrumentation should be a single verb, not a multi-step YAML exercise.
+The current implementation is a skeleton: flag parsing and command structure are done, the Kubernetes API calls are wired up but unvalidated against a real cluster, and it isn't released anywhere yet. I'll link the source here once it's public.
 
 ## What I would automate next
 

--- a/content/posts/zero-touch-go-observability-agent-actionable.md
+++ b/content/posts/zero-touch-go-observability-agent-actionable.md
@@ -1,8 +1,8 @@
 ---
 title: "Making zero-touch Go observability agent-actionable"
 description: "Turn the OBI vs. otelc decision into an agent-readable runbook, then make the Kubernetes path boring enough to run with one command."
-date: 2026-08-03T00:00:00Z
-publishDate: 2026-08-03T00:00:00Z
+date: 2026-10-06T00:00:00Z
+publishDate: 2026-10-06T00:00:00Z
 draft: true
 categories:
   - engineering


### PR DESCRIPTION
## Summary

Six draft blog posts accompanying the "How to Instrument Go Without Changing a Single Line of Code" keynote (GopherCon UK 2026). All posts have `draft: true` — none will publish until flipped.

- **why-go-cant-be-monkey-patched** — Why Go resists instrumentation; the GLS g-struct injection proof-point from dd-trace-go's orchestrion.yml
- **obi-ebpf-auto-instrumentation-go** — OBI v0.10.0 in production; precise scope (13 Go libs via uprobes), kernel 5.8+/BTF, DaemonSet vs sidecar
- **otelc-compile-time-go-traces** — orchestrion vs otelc clearly distinguished upfront; Go 1.25+ constraint; links to the existing v1 cross-post
- **continuous-profiling-go-without-code-changes** — `.gopclntab` survives strip (structural guarantee, not a quirk); OTLP profiles Alpha/Development status
- **go-runtime-futures-flight-recording-usdt** — flight recording shipped in Go 1.25 (correct struct API); #75654 HTTP/2 span gap; `mmcshane/salp` (not the 404 fork); `poc_usdt` as a working fork
- **zero-touch-go-observability-agent-actionable** — `collect-go-telemetry` skill routing logic; `kubectl obi attach` as the Kubernetes path

Post 5 (benchmark overhead shootout) follows in a separate PR once Linux benchmark numbers are available.

## Notes

- The otelc post cross-references the existing `go-compile-time-instrumentation-v1` mirror — they cover different angles (community announcement vs. practitioner take).
- Publish order: 1 → 2 → 3 → 4 → 6 → 7, with 5 inserted after benchmarks land.