### PR TITLE
chore(mcp): refresh creative writing tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,8 @@
       "mcp__pixabay__*"
     ]
   },
-  "enabledMcpjsonServers": ["meme", "giphy", "readwise", "plausible", "fal", "pexels", "pixabay"]
+  "enabledMcpjsonServers": ["meme", "giphy", "readwise", "plausible", "fal", "pexels", "pixabay"],
+  "env": {
+    "MCP_TIMEOUT": "60000"
+  }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,53 +1,87 @@
 {
   "mcpServers": {
     "meme": {
-      "command": "sh",
-      "args": [
-        "-c",
-        "IMGFLIP_USERNAME=$(op read 'op://Private/ImgFlip/username' --account my.1password.com) IMGFLIP_PASSWORD=$(op read 'op://Private/ImgFlip/password' --account my.1password.com) npx -y meme-mcp"
-      ]
+      "type": "http",
+      "url": "https://memebo.at/mcp"
     },
     "giphy": {
-      "command": "sh",
+      "command": "op",
       "args": [
-        "-c",
-        "GIPHY_API_KEY=$(op read 'op://Private/Giphy API Key/credential' --account my.1password.com) npx -y mcp-server-giphy"
-      ]
+        "--account",
+        "my.1password.com",
+        "run",
+        "--",
+        "npx",
+        "-y",
+        "mcp-server-giphy@1.0.3"
+      ],
+      "env": {
+        "GIPHY_API_KEY": "op://Private/Giphy API Key/credential"
+      }
     },
     "readwise": {
-      "command": "sh",
-      "args": [
-        "-c",
-        "ACCESS_TOKEN=$(op read 'op://Private/Readwise API Key/credential' --account my.1password.com) npx -y @readwise/readwise-mcp"
-      ]
+      "type": "http",
+      "url": "https://mcp2.readwise.io/mcp"
     },
     "plausible": {
-      "command": "sh",
+      "command": "op",
       "args": [
+        "--account",
+        "my.1password.com",
+        "run",
+        "--",
+        "sh",
         "-c",
-        "npx -y mcp-remote https://plausible-mcp.sentry.dev/mcp --header \"Authorization: Bearer $(op read 'op://Private/Plausible API Key/credential' --account my.1password.com)\""
-      ]
+        "exec npx -y mcp-remote@0.1.38 https://plausible-mcp.sentry.dev/mcp --header \"Authorization: Bearer $PLAUSIBLE_API_KEY\""
+      ],
+      "env": {
+        "PLAUSIBLE_API_KEY": "op://Private/Plausible API Key/credential"
+      }
     },
     "fal": {
-      "command": "sh",
+      "command": "op",
       "args": [
+        "--account",
+        "my.1password.com",
+        "run",
+        "--",
+        "sh",
         "-c",
-        "npx -y mcp-remote https://mcp.fal.ai/mcp --header \"Authorization: Bearer $(op read 'op://Private/Fal API Key/credential' --account my.1password.com)\""
-      ]
+        "exec npx -y mcp-remote@0.1.38 https://mcp.fal.ai/mcp --header \"Authorization: Bearer $FAL_KEY\""
+      ],
+      "env": {
+        "FAL_KEY": "op://Private/Fal API Key/credential"
+      }
     },
     "pexels": {
-      "command": "sh",
+      "command": "op",
       "args": [
-        "-c",
-        "PEXELS_API_KEY=$(op read 'op://Private/Pexels API Key/credential' --account my.1password.com) npx -y mcp-pexels"
-      ]
+        "--account",
+        "my.1password.com",
+        "run",
+        "--",
+        "npx",
+        "-y",
+        "mcp-pexels@1.0.2"
+      ],
+      "env": {
+        "PEXELS_API_KEY": "op://Private/Pexels API Key/credential"
+      }
     },
     "pixabay": {
-      "command": "sh",
+      "command": "op",
       "args": [
-        "-c",
-        "PIXABAY_API_KEY=$(op read 'op://Private/Pixabay API Key/credential' --account my.1password.com) npx -y pixabay-mcp@latest"
-      ]
+        "--account",
+        "my.1password.com",
+        "run",
+        "--",
+        "npx",
+        "-y",
+        "pixabay-mcp@0.3.0"
+      ],
+      "env": {
+        "PIXABAY_API_KEY": "op://Private/Pixabay API Key/credential"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,35 @@ Update the theme later with:
 git submodule update --remote --merge
 ```
 
+## Creative writing tools
+
+The project-level `.mcp.json` gives Claude Code tools for finding references,
+checking analytics, and adding visual material:
+
+| Server | Use |
+| --- | --- |
+| Memeboat | Search meme templates and create captioned images |
+| GIPHY | Search rated GIFs and stickers |
+| Readwise | Search highlights and Reader documents |
+| Plausible | Query site analytics |
+| fal | Find and run generative-media models |
+| Pexels | Search stock photos and videos |
+| Pixabay | Search stock photos, illustrations, vectors, and videos |
+
+The credential-backed servers require Node.js 20 or newer and the 1Password
+CLI. Their API keys remain as `op://` references and are resolved only when each
+server starts. Clones outside the author's 1Password account must replace those
+references and the `--account` value.
+
+Run `claude`, open `/mcp`, approve the project servers, and authenticate Readwise.
+`claude mcp list` shows their connection status.
+
+Download selected media into `static/uploads/` instead of depending on remote
+URLs. Keep the provider attribution with the image and add descriptive cover alt
+text. fal model execution can incur charges, so check pricing first.
+
+Pi does not load `.mcp.json`; it needs an equivalent CLI or extension integration.
+
 ## What does it include?
 
 * Overview page

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ checking analytics, and adding visual material:
 
 | Server | Use |
 | --- | --- |
-| Memeboat | Search meme templates and create captioned images |
-| GIPHY | Search rated GIFs and stickers |
-| Readwise | Search highlights and Reader documents |
-| Plausible | Query site analytics |
-| fal | Find and run generative-media models |
-| Pexels | Search stock photos and videos |
-| Pixabay | Search stock photos, illustrations, vectors, and videos |
+| `meme` | Search meme templates and create captioned images |
+| `giphy` | Search rated GIFs and stickers |
+| `readwise` | Search highlights and Reader documents |
+| `plausible` | Query site analytics |
+| `fal` | Find and run generative-media models |
+| `pexels` | Search stock photos and videos |
+| `pixabay` | Search stock photos, illustrations, vectors, and videos |
 
 The credential-backed servers require Node.js 20 or newer and the 1Password
 CLI. Their API keys remain as `op://` references and are resolved only when each
@@ -66,7 +66,8 @@ Download selected media into `static/uploads/` instead of depending on remote
 URLs. Keep the provider attribution with the image and add descriptive cover alt
 text. fal model execution can incur charges, so check pricing first.
 
-Pi does not load `.mcp.json`; it needs an equivalent CLI or extension integration.
+Pi is a separate terminal coding agent. It does not load `.mcp.json`; use an
+equivalent CLI or extension integration instead.
 
 ## What does it include?
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ Download selected media into `static/uploads/` instead of depending on remote
 URLs. Keep the provider attribution with the image and add descriptive cover alt
 text. fal model execution can incur charges, so check pricing first.
 
-Pi is a separate terminal coding agent. It does not load `.mcp.json`; use an
-equivalent CLI or extension integration instead.
-
 ## What does it include?
 
 * Overview page


### PR DESCRIPTION
## Summary

- Replace the deprecated local Readwise server and older Imgflip integration with current hosted endpoints.
- Keep Plausible, pin every npm server, and use 1Password runtime injection for credentials.
- Increase the MCP startup allowance and document the creative writing and media workflow.

## Testing

- Parsed and validated both MCP JSON files, version pins, HTTPS endpoints, and 1Password references.
- Listed tools and ran one read-only MCP Inspector 2.0.0 call against all seven servers.
- Confirmed Claude Code connects to every server after Readwise OAuth.
- Ran `make check`.
- Built with pinned Hugo 0.164.0 and ran `make verify`.
- Ran `git diff --check` and completed an independent review with no blockers.

## Notes

Paid fal generation and hosted meme creation were not invoked. The README retains 13 pre-existing MD013 and MD060 findings; the new section adds none. The production build also retains an existing Hugo template deprecation warning.
