### PR TITLE
Add GopherCon UK 2026 talk entries

### DIFF
--- a/content/talks/instrument-go-without-changing-a-single-line.md
+++ b/content/talks/instrument-go-without-changing-a-single-line.md
@@ -1,0 +1,34 @@
+---
+title: "talk: Instrument Go Without Changing a Single Line"
+description: "Zero-touch Go instrumentation across build-time, process-start, and kernel intervention points — and why the approaches complement one another rather than compete."
+date: 2026-08-13T00:00:00Z
+publishDate: 2026-08-13T00:00:00Z
+categories:
+  - talks
+tags:
+  - talks
+  - go
+  - opentelemetry
+  - auto-instrumentation
+  - ebpf
+  - observability
+---
+
+Go has no universal startup hook for instrumentation, so the available approaches act at different points in the software lifecycle. This talk maps three practical intervention points (build, process start, and kernel) and explains why they complement one another rather than compete.
+
+We cover OBI (OpenTelemetry eBPF Instrumentation), which observes running processes from the Linux kernel without rebuilding them; compile-time instrumentation via otelc and Orchestrion, which rewrites Go code during the build and preserves Go-level semantics across platforms; and the OpenTelemetry eBPF Profiler, which samples whole-node CPU activity without changing applications. Each inherits the strengths and constraints of its intervention point: OBI reaches deployed workloads but cannot infer arbitrary business semantics, while compile-time instrumentation moves earlier where source structure and dependency information are still available.
+
+We connect the signals. Tracing follows requests, profiling finds CPU cost, and the two become much stronger when they share request context. Go cannot use the native thread-local mechanism directly, so pprof labels become the bridge. The talk closes with a decision framework: start with the constraint you cannot change, then add the next layer only when its signal pays for its operational cost.
+
+**Links**
+
+* [gopherconuk-26](https://github.com/kakkoyun/gopherconuk-26) — slides, speaker notes, and repository tooling
+* [zeroins](https://github.com/kakkoyun/zeroins)
+
+**Events**
+
+* [GopherCon UK 2026](https://www.gophercon.co.uk/schedule) — Thursday 13 August 2026
+
+**Related**
+
+* [Auto-Instrumenting Go: From eBPF to USDT Probes](/posts/fosdem-2026-auto-instrumenting-go/) — full technical blog post expanding on this talk

--- a/content/talks/why-your-go-benchmarks-are-lying.md
+++ b/content/talks/why-your-go-benchmarks-are-lying.md
@@ -1,0 +1,32 @@
+---
+title: "talk: Why Your Go Benchmarks Are Lying"
+description: "A Go benchmark can report a precise number while measuring removed work, an unstable sample, or an uncontrolled machine — and trusting it requires answering three questions."
+date: 2026-08-12T00:00:00Z
+publishDate: 2026-08-12T00:00:00Z
+categories:
+  - talks
+tags:
+  - talks
+  - performance
+  - benchmarking
+  - observability
+---
+
+A benchmark is a measurement system. It can report a precise number while measuring removed work, an unstable sample, or an uncontrolled machine. This talk argues you should trust a Go benchmark only after answering three questions: Is the compiler measuring real work? Is the sample stable enough? Is the difference large relative to the noise?
+
+We work through three layers. Compiler honesty covers dead-code elimination, sinks, constant folding, inlining, timer ordering, and the `B.Loop` construct that fixes the non-terminating-timer case. Statistical interpretation covers repeated samples, benchstat, coefficient of variation, run-count discipline, and the p-hacking traps that inflate false positives. Environment control covers both local machines and CI: Linux frequency and isolation controls, perflock, benchdiff, and the bare-metal runners that shared CI instances are not.
+
+A war story from dd-trace-go ties the layers together. A benchmark measured code the PR did not touch, the same-machine result reversed the CI sign, and code layout explained the small shift that made the result directionally wrong. The repository ships the tools and captured outputs that turn those lessons into repeatable checks.
+
+**Links**
+
+* [gopherconuk-26](https://github.com/kakkoyun/gopherconuk-26) — slides, speaker notes, demo results, and the `honestbench`, `benchgate`, and `benchenv` CLIs
+* [benchlab](https://github.com/kakkoyun/benchlab)
+
+**Events**
+
+* [GopherCon UK 2026](https://www.gophercon.co.uk/schedule) — Wednesday 12 August 2026, 15:15, The Google Track
+
+**Related**
+
+* [Measuring Software Performance: Why Your Benchmarks Are Probably Lying](/posts/fosdem-2026-measuring-software-performance/) — full technical blog post expanding on this talk


### PR DESCRIPTION
Adds two talk entries for GopherCon UK 2026 (London, Aug 12–13). Recordings aren't out yet, so both entries funnel readers to the existing related blog posts instead of embedding a video. Repo links are added plainly.

## Changes

- **`content/talks/why-your-go-benchmarks-are-lying.md`** — Wed 12 Aug, 15:15, The Google Track. Funnels to `/posts/fosdem-2026-measuring-software-performance/`. Links `gopherconuk-26` + `benchlab`.
- **`content/talks/instrument-go-without-changing-a-single-line.md`** — Thu 13 Aug (future `publishDate: 2026-08-13`, hidden until the `deploy-scheduled.yml` cron flips it visible on the day). Funnels to `/posts/fosdem-2026-auto-instrumenting-go/`. Links `gopherconuk-26` + `zeroins`.

## Notes

- No `cover` / `Recording` embed — added when the videos are published.
- No `promote: false` — talks are outside the social-promotion pipeline (`find-promotable-posts.sh` scans `content/posts/*.md` only), matching every existing talk entry.
- The "what it's about" paragraphs are drawn from the talk outlines in the `gopherconuk-26` repo, not the GopherCon UK schedule (whose benchmarking description is wrong).
- Talk 2's `date` and `publishDate` are both `2026-08-13` so the headline renders the correct day; `publishDate` keeps it hidden in production until the 13th.

## Verification

- Hugo 0.164.0 build: both pages render (HTML + markdown alternates).
- Production build (no `--buildFuture`): Talk 1 visible, Talk 2 hidden (correct).
- Preview build (`--buildFuture`): Talk 2 visible.
- Both `Related` links resolve to existing posts.
- Vale: 0 errors, 0 warnings, 0 suggestions.
