### PR TITLE
Update GopherCon UK 2026 talk page for the restructured deck

### DIFF
--- a/content/talks/instrument-go-without-changing-a-single-line.md
+++ b/content/talks/instrument-go-without-changing-a-single-line.md
@@ -14,16 +14,44 @@ tags:
   - observability
 ---
 
-Go has no universal startup hook for instrumentation, so the available approaches act at different points in the software lifecycle. This talk maps three practical intervention points (build, process start, and kernel) and explains why they complement one another rather than compete.
+The debugging loop is slow. You cannot reproduce the bug locally, so you add a
+log line and redeploy. Wrong place. You do it again. An agent alone does not
+fix this: it still has to pick a mechanism, and it has to know what that
+mechanism costs.
 
-We cover OBI (OpenTelemetry eBPF Instrumentation), which observes running processes from the Linux kernel without rebuilding them; compile-time instrumentation via otelc and Orchestrion, which rewrites Go code during the build and preserves Go-level semantics across platforms; and the OpenTelemetry eBPF Profiler, which samples whole-node CPU activity without changing applications. Each inherits the strengths and constraints of its intervention point: OBI reaches deployed workloads but cannot infer arbitrary business semantics, while compile-time instrumentation moves earlier where source structure and dependency information are still available.
+This talk is about three open-source approaches that take the rebuild out of
+that loop. Each acts at a different point in the software lifecycle, and each
+inherits the strengths and constraints of its intervention point.
 
-We connect the signals. Tracing follows requests, profiling finds CPU cost, and the two become much stronger when they share request context. Go cannot use the native thread-local mechanism directly, so pprof labels become the bridge. The talk closes with a decision framework: start with the constraint you cannot change, then add the next layer only when its signal pays for its operational cost.
+**Build time.** [otelc](https://opentelemetry.io/docs/zero-code/go/compile-time/)
+rewrites Go code during the build via `-toolexec`, preserving Go-level semantics
+across platforms. The rebuild is the cost.
+
+**Process start.** An injector loads a shared library at startup via
+`LD_PRELOAD`. No source change, no rebuild. The binary is the constraint.
+
+**Kernel.** [OBI](https://opentelemetry.io/docs/zero-code/obi/) (OpenTelemetry
+eBPF Instrumentation) observes running processes from the Linux kernel without
+rebuilding them. Linux, privileges, and kernel contracts are the cost.
+
+We connect the signals. Tracing follows requests, profiling finds CPU cost,
+and the two become much stronger when they share request context. Go cannot use
+the native thread-local mechanism directly, so [pprof labels become the
+bridge](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/4947-thread-ctx.md#alternative-for-go-support).
+The [OpenTelemetry eBPF Profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)
+samples whole-node CPU activity without changing applications, and `.gopclntab`
+survives even fully stripped static binaries.
+
+The talk closes with a decision framework: start with the constraint you
+cannot change, then add the next layer only when its signal pays for its
+operational cost.
 
 **Links**
 
-* [gopherconuk-26](https://github.com/kakkoyun/gopherconuk-26) — slides, speaker notes, and repository tooling
-* [zeroins](https://github.com/kakkoyun/zeroins)
+* [gopherconuk-26](https://github.com/kakkoyun/gopherconuk-26) — slides, speaker notes, and research
+* [zeroins](https://github.com/kakkoyun/zeroins) — offline catalog and agent skill toolkit
+* [opentelemetry-agent-skills](https://github.com/ollygarden/opentelemetry-agent-skills) — agent skills for instrumenting Go applications
+* [OpenTelemetry community](https://github.com/open-telemetry/community) — SIG calendars, notes, and channels
 
 **Events**
 


### PR DESCRIPTION
## What

Updates the GopherCon UK 2026 talk page to match the restructured deck.

## Why

The deck was restructured from a 52-page survey into a 66-page keynote with a debugging-loop arc. The talk page body needed to match the new narrative.

## Changes

- Body rewritten to match the new arc: open on the debugging loop, three approaches (build, process start, kernel), injector as the third leg, signal correlation, decision framework
- Added inline links to otelc docs, OBI docs, OTEP 4947, and the eBPF profiler repo
- Added `opentelemetry-agent-skills` and `OpenTelemetry community` to the links section
- Dropped the redundant "repository tooling" label